### PR TITLE
add more-css

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ A comparison of CSS minification engines.
 * [csso](https://github.com/css/csso)
 * [cssshrink](https://github.com/stoyan/cssshrink)
 * [csswring](https://github.com/hail2u/node-csswring)
+* [more-css](https://github.com/army8735/more)
 * [ncss](https://github.com/kurakin/ncss)
 * [sqwish](https://github.com/ded/sqwish)
 * [ycssmin](https://github.com/yui/ycssmin)

--- a/bin/bench
+++ b/bin/bench
@@ -9,6 +9,7 @@ var cssCondense = require('css-condense');
 var csso = require('csso');
 var cssshrink = require('cssshrink');
 var csswring = require('csswring');
+var moreCss = require('more-css');
 var ncss = require('ncss');
 var sqwish = require('sqwish');
 var ycssmin = require('ycssmin');
@@ -45,6 +46,9 @@ var minifiers = {
   'cssshrink': cssshrink.shrink,
   'csswring': function (source) {
      return csswring.wring(source).css;
+  },
+  'more-css': function(source) {
+    return moreCss.compress(source, true);
   },
   'ncss': ncss,
   'sqwish': sqwish.minify,

--- a/index.html
+++ b/index.html
@@ -20,6 +20,7 @@
 <th><a href="https://github.com/css/csso.git">csso (reordering off) - 1.3.11</a></th>
 <th><a href="https://github.com/stoyan/cssshrink.git">cssshrink - 0.0.5</a></th>
 <th><a href="https://github.com/hail2u/node-csswring.git">csswring - 1.3.0</a></th>
+<th><a href="https://github.com/army8735/more.git">more-css - 0.7.5</a></th>
 <th><a href="https://github.com/kurakin/ncss.git">ncss - 1.1.1</a></th>
 <th>sqwish - 0.2.2</th>
 <th><a href="http://github.com/yui/ycssmin.git">ycssmin - 1.0.1</a></th>
@@ -27,16 +28,17 @@
 <tbody>
 <tr>
 <td>960.css - <em>9989 bytes</em></td>
-<td class='success'>5772 bytes</td>
-<td class='success'>5772 bytes</td>
-<td class='success'>5772 bytes</td>
-<td class='success'>5772 bytes</td>
-<td class='success'>5772 bytes</td>
-<td class='success'>5772 bytes</td>
-<td class='success'>5772 bytes</td>
-<td class='success'>5772 bytes</td>
-<td class='success'>5772 bytes</td>
-<td class='success'>5772 bytes</td>
+<td class='danger'>5772 bytes</td>
+<td class='danger'>5772 bytes</td>
+<td class='danger'>5772 bytes</td>
+<td class='danger'>5772 bytes</td>
+<td class='danger'>5772 bytes</td>
+<td class='danger'>5772 bytes</td>
+<td class='danger'>5772 bytes</td>
+<td class='success'>5768 bytes</td>
+<td class='danger'>5772 bytes</td>
+<td class='danger'>5772 bytes</td>
+<td class='danger'>5772 bytes</td>
 </tr>
 <tr>
 <td>animate.css - <em>72921 bytes</em></td>
@@ -47,32 +49,35 @@
 <td>52989 bytes</td>
 <td>52921 bytes</td>
 <td>53281 bytes</td>
+<td>53064 bytes</td>
 <td>53397 bytes</td>
 <td class='danger'>53677 bytes</td>
 <td class='danger'>53677 bytes</td>
 </tr>
 <tr>
 <td>blueprint.css - <em>17422 bytes</em></td>
-<td class='success'>10705 bytes</td>
+<td>10705 bytes</td>
 <td>10796 bytes</td>
 <td>10807 bytes</td>
 <td>10796 bytes</td>
 <td>10796 bytes</td>
 <td>10794 bytes</td>
 <td>10785 bytes</td>
+<td class='success'>10524 bytes</td>
 <td>10805 bytes</td>
 <td class='danger'>10815 bytes</td>
 <td>10805 bytes</td>
 </tr>
 <tr>
 <td>bootstrap.css - <em>132544 bytes</em></td>
-<td class='success'>108346 bytes</td>
+<td>108346 bytes</td>
 <td>109286 bytes</td>
 <td>109535 bytes</td>
 <td>108760 bytes</td>
 <td>109373 bytes</td>
 <td>108593 bytes</td>
 <td>109239 bytes</td>
+<td class='success'>107218 bytes</td>
 <td class='danger'>error</td>
 <td class='danger'>112198 bytes</td>
 <td>109419 bytes</td>
@@ -86,84 +91,91 @@
 <td>21777 bytes</td>
 <td>21794 bytes</td>
 <td class='success'>21762 bytes</td>
+<td>21791 bytes</td>
 <td>21813 bytes</td>
 <td class='danger'>21816 bytes</td>
 <td>21811 bytes</td>
 </tr>
 <tr>
 <td>foundation.css - <em>180512 bytes</em></td>
-<td class='success'>133789 bytes</td>
+<td>133789 bytes</td>
 <td>140494 bytes</td>
 <td>141417 bytes</td>
 <td>134598 bytes</td>
 <td>140940 bytes</td>
 <td>136369 bytes</td>
 <td>140524 bytes</td>
+<td class='success'>129719 bytes</td>
 <td>141204 bytes</td>
 <td class='danger'>142701 bytes</td>
 <td>141248 bytes</td>
 </tr>
 <tr>
 <td>gumby.css - <em>186244 bytes</em></td>
-<td class='success'>152417 bytes</td>
+<td>152417 bytes</td>
 <td>170195 bytes</td>
 <td>170830 bytes</td>
 <td>153174 bytes</td>
 <td>170737 bytes</td>
 <td>170290 bytes</td>
 <td>170480 bytes</td>
+<td class='success'>151179 bytes</td>
 <td class='danger'>error</td>
 <td class='danger'>171119 bytes</td>
 <td>170644 bytes</td>
 </tr>
 <tr>
 <td>inuit.css - <em>53049 bytes</em></td>
-<td class='success'>17946 bytes</td>
+<td>17946 bytes</td>
 <td>18185 bytes</td>
 <td>18222 bytes</td>
 <td>17954 bytes</td>
 <td>18206 bytes</td>
 <td>18191 bytes</td>
 <td>18189 bytes</td>
+<td class='success'>17610 bytes</td>
 <td>18203 bytes</td>
 <td class='danger'>18263 bytes</td>
 <td>18206 bytes</td>
 </tr>
 <tr>
 <td>normalize.css - <em>7797 bytes</em></td>
-<td class='success'>1921 bytes</td>
-<td class='success'>1921 bytes</td>
+<td>1921 bytes</td>
+<td>1921 bytes</td>
 <td>1946 bytes</td>
 <td>1941 bytes</td>
 <td>1941 bytes</td>
 <td>1931 bytes</td>
-<td class='success'>1921 bytes</td>
+<td>1921 bytes</td>
+<td class='success'>1872 bytes</td>
 <td>1946 bytes</td>
 <td class='danger'>1950 bytes</td>
 <td>1946 bytes</td>
 </tr>
 <tr>
 <td>oocss.css - <em>40151 bytes</em></td>
-<td class='success'>14317 bytes</td>
+<td>14317 bytes</td>
 <td>14510 bytes</td>
 <td>14764 bytes</td>
 <td>14469 bytes</td>
 <td>14753 bytes</td>
 <td>14588 bytes</td>
 <td>14713 bytes</td>
+<td class='success'>14223 bytes</td>
 <td>14755 bytes</td>
 <td class='danger'>14862 bytes</td>
 <td>14755 bytes</td>
 </tr>
 <tr>
 <td>pure.css - <em>35136 bytes</em></td>
-<td class='success'>17249 bytes</td>
+<td>17249 bytes</td>
 <td>17859 bytes</td>
 <td>18867 bytes</td>
 <td>18838 bytes</td>
 <td>18838 bytes</td>
 <td>18464 bytes</td>
 <td>18591 bytes</td>
+<td class='success'>17046 bytes</td>
 <td>18866 bytes</td>
 <td class='danger'>18992 bytes</td>
 <td>18891 bytes</td>
@@ -177,6 +189,7 @@
 <td class='danger'>773 bytes</td>
 <td class='danger'>773 bytes</td>
 <td class='danger'>773 bytes</td>
+<td class='success'>758 bytes</td>
 <td class='danger'>773 bytes</td>
 <td class='danger'>773 bytes</td>
 <td class='danger'>773 bytes</td>

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "cssshrink": "0.0.x",
     "csswring": "1.3.x",
     "jshint": "2.5.x",
+    "more-css": "0.7.x",
     "ncss": "1.1.x",
     "sqwish": "0.2.x",
     "ycssmin": "1.0.x"


### PR DESCRIPTION
`more-css` is a pre-compiler & compressor,
It do more aggressive merging on minifying CSS like this:

``` css
.a{margin:0;padding:0}.b{margin:0;color:#FFF}.c{padding:0;color:#FFF}
```

to

``` css
.a,.c{padding:0}.a,.b{margin:0}.b,.c{color:#FFF}
```

And this is not allowed because `margin` is conflict:

``` css
.a{margin:0;padding:0}.b{margin-top:0}.c{margin:0;padding:0}
```

to

``` css
.a,.c{padding:0}.a{margin:0}.b{margin-top:0}.c{margin:0}
```

Also this is not allowed because the selector is longer than the css value

``` css
.aaaaaa{margin:0;padding:0}.b{margin:1}.ccccccc{margin:0;padding:0}
```

to

``` css
.aaaaaa{margin:0;padding:0}.b{margin:1}.ccccccc{margin:0;padding:0}
```
