### PR TITLE
Split tables

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,10 @@ Note that on Windows you will need to do `node ./bin/bench`
 
 If you prefer to see results without cloning the repo here are [the most recent ones](http://goalsmashers.github.io/css-minification-benchmark/).
 
+### How can I generate the html remport
+
+Just run `./bin/bench --html > report.html`
+
 ### How can I test my CSS file?
 
 Just copy your file to `data` directory (make sure filename ends with `.css`) and re-run the benchmark.
@@ -38,6 +42,10 @@ Please make sure your file does not contain any special comments (`/*! ... */`) 
 * `clean-css` has it configurable but leaves all by default
 * `csso` always leaves one
 * `ncss` and `ycssmin` always leave all
+
+### Can I get the total size and time for my CSS files?
+
+Copy all you files to `data` directory like before and run the benchmark with `--total`.
 
 ### How can I add a new minifier to the list?
 

--- a/README.md
+++ b/README.md
@@ -60,6 +60,10 @@ Copy all you files to `data` directory like before and run the benchmark with `-
 
 Just run `./bin/bench --only ncss,ycssmin` (it's turned into `/.*(ncss|ycsmin).*/` regex)
 
+### Can I get the compressed gzip size as well?
+
+Run `./bin/bench --gzip` to measure the gzip size instead of the regular file size.
+
 ## License
 
 css-minification-benchmark is released under the [MIT License](https://github.com/GoalSmashers/clean-css/blob/master/LICENSE).

--- a/README.md
+++ b/README.md
@@ -64,6 +64,10 @@ Just run `./bin/bench --only ncss,ycssmin` (it's turned into `/.*(ncss|ycsmin).*
 
 Run `./bin/bench --gzip` to measure the gzip size instead of the regular file size.
 
+### Can I get a more detailed table?
+
+You can split the size and time measure using `--verbose`.
+
 ## License
 
 css-minification-benchmark is released under the [MIT License](https://github.com/GoalSmashers/clean-css/blob/master/LICENSE).

--- a/bin/bench
+++ b/bin/bench
@@ -10,11 +10,11 @@ process.stdout.write = function() {};
 var only = process.argv.indexOf('--only') > -1 ?
   new RegExp('.*(' + process.argv[process.argv.indexOf('--only') + 1].replace(/,/g, '|') + ').*') :
   /.+/;
-var asHTML = process.argv.indexOf('--html') > -1;
 
 var input = fs.readdirSync('data');
 
 bench({
   only: only,
-  asHTML: asHTML
+  asHTML: process.argv.indexOf('--html') > -1,
+  total: process.argv.indexOf('--total') > -1
 }, input, output);

--- a/bin/bench
+++ b/bin/bench
@@ -1,10 +1,7 @@
 #!/usr/bin/env node
 var fs = require('fs');
 var bench = require('../lib/bench');
-
-// mock it to drop output from ncss
-var output = process.stdout.write.bind(process.stdout);
-process.stdout.write = function() {};
+var processOutput = require('../lib/process-output');
 
 // ARGUMENTS
 var only = process.argv.indexOf('--only') > -1 ?
@@ -12,10 +9,14 @@ var only = process.argv.indexOf('--only') > -1 ?
   /.+/;
 
 var input = fs.readdirSync('data');
+var asHTML = process.argv.indexOf('--html') > -1;
+var measureGzip = process.argv.indexOf('--gzip') > -1;
+var total = process.argv.indexOf('--total') > -1;
+var verbose = process.argv.indexOf('--verbose') > -1;
+var output = processOutput.getOutput(asHTML, measureGzip, total, verbose);
 
 bench({
   only: only,
-  asHTML: process.argv.indexOf('--html') > -1,
-  total: process.argv.indexOf('--total') > -1,
-  gzip: process.argv.indexOf('--gzip') > -1
+  total: total,
+  gzip: measureGzip
 }, input, output);

--- a/bin/bench
+++ b/bin/bench
@@ -16,5 +16,6 @@ var input = fs.readdirSync('data');
 bench({
   only: only,
   asHTML: process.argv.indexOf('--html') > -1,
-  total: process.argv.indexOf('--total') > -1
+  total: process.argv.indexOf('--total') > -1,
+  gzip: process.argv.indexOf('--gzip') > -1
 }, input, output);

--- a/bin/bench
+++ b/bin/bench
@@ -1,26 +1,10 @@
 #!/usr/bin/env node
+var fs = require('fs');
+var bench = require('../lib/bench');
 
 // mock it to drop output from ncss
 var output = process.stdout.write.bind(process.stdout);
 process.stdout.write = function() {};
-
-var CleanCSS = require('clean-css');
-var cssCondense = require('css-condense');
-var csso = require('csso');
-var cssshrink = require('cssshrink');
-var csswring = require('csswring');
-var moreCss = require('more-css');
-var ncss = require('ncss');
-var sqwish = require('sqwish');
-var ycssmin = require('ycssmin');
-
-var Table = require('cli-table');
-var HTMLTable = require('../lib/html-table');
-var fs = require('fs');
-var path = require('path');
-require('colors');
-
-var lineBreak = require('os').EOL;
 
 // ARGUMENTS
 var only = process.argv.indexOf('--only') > -1 ?
@@ -28,144 +12,9 @@ var only = process.argv.indexOf('--only') > -1 ?
   /.+/;
 var asHTML = process.argv.indexOf('--html') > -1;
 
-// MINIFIERS
-var minifiers = {
-  'clean-css': function(source) {
-    return new CleanCSS({ processImport: false }).minify(source).styles;
-  },
-  'clean-css (advanced off)': function(source) {
-    return new CleanCSS({ advanced: false, processImport: false }).minify(source).styles;
-  },
-  'css-condense': function(source) {
-    return cssCondense.compress(source, { safe: true });
-  },
-  'csso': csso.justDoIt,
-  'csso (reordering off)': function(source) {
-    return csso.justDoIt(source, true);
-  },
-  'cssshrink': cssshrink.shrink,
-  'csswring': function (source) {
-    return csswring.wring(source).css;
-  },
-  'more-css': function(source) {
-    return moreCss.compress(source, true);
-  },
-  'ncss': ncss,
-  'sqwish': sqwish.minify,
-  'ycssmin': ycssmin.cssmin
-};
+var input = fs.readdirSync('data');
 
-var activeMinifiers = [];
-for (var name in minifiers) {
-  if (only.test(name))
-    activeMinifiers.push(name);
-}
-
-// FORMATTING
-var styled = function(value, color, bootstrapClass) {
-  return asHTML ?
-    { 'class': bootstrapClass, value: value } :
-    value[color];
-};
-
-// RUN BENCHMARK
-var minifierNames = activeMinifiers.slice(0).map(function(name) {
-  var packageName = name.split(' ')[0];
-  var packageDefinition = JSON.parse(fs.readFileSync(path.join('node_modules', packageName, 'package.json')));
-  var repositoryUrl = packageDefinition.repository &&
-    packageDefinition.repository.url &&
-    packageDefinition.repository.url.replace(/^git:\/\//, 'https://');
-  var version = packageDefinition.version;
-
-  if (asHTML && repositoryUrl)
-    return '<a href="' + repositoryUrl + '">' + name + ' - ' + version + '</a>';
-  else
-    return name + ' - ' + version;
-});
-minifierNames.unshift('');
-
-var tableClass = asHTML ? HTMLTable : Table;
-var results = new tableClass({ head: minifierNames });
-
-var comparator = function(n1, n2) {
-  return n1 > n2 ? 1 : -1;
-};
-var benchmark = function(filename) {
-  if (filename.indexOf('.css') == -1)
-    return;
-
-  var source = fs.readFileSync(path.join('data', filename), 'utf8');
-  var size = asHTML ?
-    ' - <em>' + source.length + ' bytes</em>' :
-    ' - ' + source.length + ' bytes';
-  var row = [filename + size];
-  var sizes = [];
-  var times = [];
-
-  activeMinifiers.forEach(function(name) {
-    try {
-      var start = process.hrtime();
-      var minified = minifiers[name](source);
-      var itTook = process.hrtime(start);
-      var took = Math.round((1000 * itTook[0] + itTook[1] / 1000000) * 100) / 100;
-
-      sizes.push(minified.length);
-      times.push(took);
-      row.push({ size: minified.length, time: took });
-      process.stderr.write('.');
-    } catch (e) {
-      row.push({ size: -1, time: -1 });
-      process.stderr.write('F');
-    }
-  });
-
-  sizes = sizes.sort(comparator);
-  times = times.sort(comparator);
-
-  row = row.map(function(result) {
-    if (result.time == -1)
-      return styled('error', 'red', 'danger');
-    if (typeof result == 'string')
-      return result;
-
-    // var value = result.size + ' bytes (' + result.time + ' ms)';
-    var value = result.size + ' bytes';
-    var valueStyled = value;
-    var formatted = asHTML ? {} : '';
-
-    if (result.size == sizes[sizes.length - 1] && sizes.length > 1 && sizes[0] != sizes[sizes.length - 1])
-      valueStyled = styled(value, 'red', 'danger');
-    if (result.size == sizes[0])
-      valueStyled = styled(value, 'green', 'success');
-
-    if (asHTML) {
-      formatted.size = valueStyled.value || value;
-      formatted.sizeClass = valueStyled.class || 'default';
-    }
-    else
-      formatted = valueStyled;
-
-    valueStyled = value = result.time + ' ms';
-
-    if (result.time == times[times.length - 1] && times.length > 1 && times[0] != times[times.length - 1])
-      valueStyled = styled(value, 'red', 'danger');
-    if (result.time == times[0])
-      valueStyled = styled(value, 'green', 'success');
-    if (asHTML) {
-      formatted.time = valueStyled.value || value;
-      formatted.timeClass = valueStyled.class || 'default';
-    }
-    else
-      formatted += ' - ' + valueStyled;
-
-    return formatted;
-  });
-
-  results.push(row);
-};
-
-fs.readdirSync('data').forEach(benchmark);
-
-output(lineBreak);
-output(results.toString());
-output(lineBreak);
+bench({
+  only: only,
+  asHTML: asHTML
+}, input, output);

--- a/lib/bench.js
+++ b/lib/bench.js
@@ -1,0 +1,168 @@
+#!/usr/bin/env node
+module.exports = function (args, input, output) {
+
+  var CleanCSS = require('clean-css');
+  var cssCondense = require('css-condense');
+  var csso = require('csso');
+  var cssshrink = require('cssshrink');
+  var csswring = require('csswring');
+  var moreCss = require('more-css');
+  var ncss = require('ncss');
+  var sqwish = require('sqwish');
+  var ycssmin = require('ycssmin');
+
+  var Table = require('cli-table');
+  var HTMLTable = require('./html-table');
+  var fs = require('fs');
+  var path = require('path');
+  require('colors');
+
+  var lineBreak = require('os').EOL;
+
+  // ARGUMENTS
+  var only = args.only;
+  var asHTML = args.asHTML;
+
+  // MINIFIERS
+  var minifiers = {
+    'clean-css': function(source) {
+      return new CleanCSS({ processImport: false }).minify(source).styles;
+    },
+    'clean-css (advanced off)': function(source) {
+      return new CleanCSS({ advanced: false, processImport: false }).minify(source).styles;
+    },
+    'css-condense': function(source) {
+      return cssCondense.compress(source, { safe: true });
+    },
+    'csso': csso.justDoIt,
+    'csso (reordering off)': function(source) {
+      return csso.justDoIt(source, true);
+    },
+    'cssshrink': cssshrink.shrink,
+    'csswring': function (source) {
+      return csswring.wring(source).css;
+    },
+    'more-css': function(source) {
+      return moreCss.compress(source, true);
+    },
+    'ncss': ncss,
+    'sqwish': sqwish.minify,
+    'ycssmin': ycssmin.cssmin
+  };
+
+  var activeMinifiers = [];
+  for (var name in minifiers) {
+    if (only.test(name))
+      activeMinifiers.push(name);
+  }
+
+  // FORMATTING
+  var styled = function(value, color, bootstrapClass) {
+    return asHTML ?
+      { 'class': bootstrapClass, value: value } :
+      value[color];
+  };
+
+  // RUN BENCHMARK
+  var minifierNames = activeMinifiers.slice(0).map(function(name) {
+    var packageName = name.split(' ')[0];
+    var packageDefinition = JSON.parse(fs.readFileSync(path.join('node_modules', packageName, 'package.json')));
+    var repositoryUrl = packageDefinition.repository &&
+      packageDefinition.repository.url &&
+      packageDefinition.repository.url.replace(/^git:\/\//, 'https://');
+    var version = packageDefinition.version;
+
+    if (asHTML && repositoryUrl)
+      return '<a href="' + repositoryUrl + '">' + name + ' - ' + version + '</a>';
+    else
+      return name + ' - ' + version;
+  });
+  minifierNames.unshift('');
+
+  var tableClass = asHTML ? HTMLTable : Table;
+  var results = new tableClass({ head: minifierNames });
+
+  var comparator = function(n1, n2) {
+    return n1 > n2 ? 1 : -1;
+  };
+  var benchmark = function(filename) {
+    if (filename.indexOf('.css') == -1)
+      return;
+
+    var source = fs.readFileSync(path.join('data', filename), 'utf8');
+    var size = asHTML ?
+      ' - <em>' + source.length + ' bytes</em>' :
+      ' - ' + source.length + ' bytes';
+    var row = [filename + size];
+    var sizes = [];
+    var times = [];
+
+    activeMinifiers.forEach(function(name) {
+      try {
+        var start = process.hrtime();
+        var minified = minifiers[name](source);
+        var itTook = process.hrtime(start);
+        var took = Math.round((1000 * itTook[0] + itTook[1] / 1000000) * 100) / 100;
+
+        sizes.push(minified.length);
+        times.push(took);
+        row.push({ size: minified.length, time: took });
+        process.stderr.write('.');
+      } catch (e) {
+        row.push({ size: -1, time: -1 });
+        process.stderr.write('F');
+      }
+    });
+
+    sizes = sizes.sort(comparator);
+    times = times.sort(comparator);
+
+    row = row.map(function(result) {
+      if (result.time == -1)
+        return styled('error', 'red', 'danger');
+      if (typeof result == 'string')
+        return result;
+
+      // var value = result.size + ' bytes (' + result.time + ' ms)';
+      var value = result.size + ' bytes';
+      var valueStyled = value;
+      var formatted = asHTML ? {} : '';
+
+      if (result.size == sizes[sizes.length - 1] && sizes.length > 1 && sizes[0] != sizes[sizes.length - 1])
+        valueStyled = styled(value, 'red', 'danger');
+      if (result.size == sizes[0])
+        valueStyled = styled(value, 'green', 'success');
+
+      if (asHTML) {
+        formatted.size = valueStyled.value || value;
+        formatted.sizeClass = valueStyled.class || 'default';
+      }
+      else
+        formatted = valueStyled;
+
+      valueStyled = value = result.time + ' ms';
+
+      if (result.time == times[times.length - 1] && times.length > 1 && times[0] != times[times.length - 1])
+        valueStyled = styled(value, 'red', 'danger');
+      if (result.time == times[0])
+        valueStyled = styled(value, 'green', 'success');
+      if (asHTML) {
+        formatted.time = valueStyled.value || value;
+        formatted.timeClass = valueStyled.class || 'default';
+      }
+      else
+        formatted += ' - ' + valueStyled;
+
+      return formatted;
+    });
+
+    results.push(row);
+  };
+
+  input.forEach(benchmark);
+
+  output(lineBreak);
+  output(results.toString());
+  output(lineBreak);
+
+};

--- a/lib/bench.js
+++ b/lib/bench.js
@@ -1,20 +1,11 @@
 #!/usr/bin/env node
 module.exports = function (args, input, output) {
 
-  var CleanCSS = require('clean-css');
-  var cssCondense = require('css-condense');
-  var csso = require('csso');
-  var cssshrink = require('cssshrink');
-  var csswring = require('csswring');
-  var moreCss = require('more-css');
-  var ncss = require('ncss');
-  var sqwish = require('sqwish');
-  var ycssmin = require('ycssmin');
-
   var Table = require('cli-table');
   var HTMLTable = require('./html-table');
   var formatRow = require('./format-row');
   var storage = require('./storage');
+  var minify = require('./minify');
   var fs = require('fs');
   var path = require('path');
   require('colors');
@@ -25,39 +16,9 @@ module.exports = function (args, input, output) {
   var only = args.only;
   var asHTML = args.asHTML;
   var showTotal = args.total;
+  var measureGzip = args.gzip;
 
-  // MINIFIERS
-  var minifiers = {
-    'clean-css': function(source) {
-      return new CleanCSS({ processImport: false }).minify(source).styles;
-    },
-    'clean-css (advanced off)': function(source) {
-      return new CleanCSS({ advanced: false, processImport: false }).minify(source).styles;
-    },
-    'css-condense': function(source) {
-      return cssCondense.compress(source, { safe: true });
-    },
-    'csso': csso.justDoIt,
-    'csso (reordering off)': function(source) {
-      return csso.justDoIt(source, true);
-    },
-    'cssshrink': cssshrink.shrink,
-    'csswring': function (source) {
-      return csswring.wring(source).css;
-    },
-    'more-css': function(source) {
-      return moreCss.compress(source, true);
-    },
-    'ncss': ncss,
-    'sqwish': sqwish.minify,
-    'ycssmin': ycssmin.cssmin
-  };
-
-  var activeMinifiers = [];
-  for (var name in minifiers) {
-    if (only.test(name))
-      activeMinifiers.push(name);
-  }
+  var activeMinifiers = minify.getActive(only);
 
   // RUN BENCHMARK
   var minifierNames = activeMinifiers.slice(0).map(function(name) {
@@ -92,12 +53,9 @@ module.exports = function (args, input, output) {
 
     activeMinifiers.forEach(function(name) {
       try {
-        var start = process.hrtime();
-        var minified = minifiers[name](source);
-        var itTook = process.hrtime(start);
-        var took = Math.round((1000 * itTook[0] + itTook[1] / 1000000) * 100) / 100;
+        var stats = minify.measure(name, source, measureGzip);
 
-        storage.save(filename, name, minified.length, took);
+        storage.save(filename, name, stats);
         process.stderr.write('.');
       } catch (e) {
         storage.save(filename, name, NaN, NaN);
@@ -106,7 +64,7 @@ module.exports = function (args, input, output) {
     });
 
     activeMinifiers.forEach(function(name) {
-      row.push(formatRow(asHTML, storage.get(filename, name)));
+      row.push(formatRow(asHTML, storage.get(filename, name), measureGzip));
     });
 
     results.push(row);
@@ -121,7 +79,7 @@ module.exports = function (args, input, output) {
       (totalLength + ' bytes')
     )];
     activeMinifiers.forEach(function(name) {
-      totalRow.push(formatRow(asHTML, storage.total(name)));
+      totalRow.push(formatRow(asHTML, storage.total(name), measureGzip));
     });
     results.push(totalRow);
   }

--- a/lib/bench.js
+++ b/lib/bench.js
@@ -13,6 +13,8 @@ module.exports = function (args, input, output) {
 
   var Table = require('cli-table');
   var HTMLTable = require('./html-table');
+  var formatRow = require('./format-row');
+  var storage = require('./storage');
   var fs = require('fs');
   var path = require('path');
   require('colors');
@@ -22,6 +24,7 @@ module.exports = function (args, input, output) {
   // ARGUMENTS
   var only = args.only;
   var asHTML = args.asHTML;
+  var showTotal = args.total;
 
   // MINIFIERS
   var minifiers = {
@@ -56,13 +59,6 @@ module.exports = function (args, input, output) {
       activeMinifiers.push(name);
   }
 
-  // FORMATTING
-  var styled = function(value, color, bootstrapClass) {
-    return asHTML ?
-      { 'class': bootstrapClass, value: value } :
-      value[color];
-  };
-
   // RUN BENCHMARK
   var minifierNames = activeMinifiers.slice(0).map(function(name) {
     var packageName = name.split(' ')[0];
@@ -81,10 +77,8 @@ module.exports = function (args, input, output) {
 
   var tableClass = asHTML ? HTMLTable : Table;
   var results = new tableClass({ head: minifierNames });
+  var totalLength = 0;
 
-  var comparator = function(n1, n2) {
-    return n1 > n2 ? 1 : -1;
-  };
   var benchmark = function(filename) {
     if (filename.indexOf('.css') == -1)
       return;
@@ -94,8 +88,7 @@ module.exports = function (args, input, output) {
       ' - <em>' + source.length + ' bytes</em>' :
       ' - ' + source.length + ' bytes';
     var row = [filename + size];
-    var sizes = [];
-    var times = [];
+    totalLength += source.length;
 
     activeMinifiers.forEach(function(name) {
       try {
@@ -104,62 +97,34 @@ module.exports = function (args, input, output) {
         var itTook = process.hrtime(start);
         var took = Math.round((1000 * itTook[0] + itTook[1] / 1000000) * 100) / 100;
 
-        sizes.push(minified.length);
-        times.push(took);
-        row.push({ size: minified.length, time: took });
+        storage.save(filename, name, minified.length, took);
         process.stderr.write('.');
       } catch (e) {
-        row.push({ size: -1, time: -1 });
+        storage.save(filename, name, NaN, NaN);
         process.stderr.write('F');
       }
     });
 
-    sizes = sizes.sort(comparator);
-    times = times.sort(comparator);
-
-    row = row.map(function(result) {
-      if (result.time == -1)
-        return styled('error', 'red', 'danger');
-      if (typeof result == 'string')
-        return result;
-
-      // var value = result.size + ' bytes (' + result.time + ' ms)';
-      var value = result.size + ' bytes';
-      var valueStyled = value;
-      var formatted = asHTML ? {} : '';
-
-      if (result.size == sizes[sizes.length - 1] && sizes.length > 1 && sizes[0] != sizes[sizes.length - 1])
-        valueStyled = styled(value, 'red', 'danger');
-      if (result.size == sizes[0])
-        valueStyled = styled(value, 'green', 'success');
-
-      if (asHTML) {
-        formatted.size = valueStyled.value || value;
-        formatted.sizeClass = valueStyled.class || 'default';
-      }
-      else
-        formatted = valueStyled;
-
-      valueStyled = value = result.time + ' ms';
-
-      if (result.time == times[times.length - 1] && times.length > 1 && times[0] != times[times.length - 1])
-        valueStyled = styled(value, 'red', 'danger');
-      if (result.time == times[0])
-        valueStyled = styled(value, 'green', 'success');
-      if (asHTML) {
-        formatted.time = valueStyled.value || value;
-        formatted.timeClass = valueStyled.class || 'default';
-      }
-      else
-        formatted += ' - ' + valueStyled;
-
-      return formatted;
+    activeMinifiers.forEach(function(name) {
+      row.push(formatRow(asHTML, storage.get(filename, name)));
     });
 
     results.push(row);
   };
 
+
   input.forEach(benchmark);
+
+  if (showTotal) {
+    var totalRow = ['TOTAL - ' + (asHTML ?
+      ('<em>' + totalLength + ' bytes</em>') :
+      (totalLength + ' bytes')
+    )];
+    activeMinifiers.forEach(function(name) {
+      totalRow.push(formatRow(asHTML, storage.total(name)));
+    });
+    results.push(totalRow);
+  }
 
   output(lineBreak);
   output(results.toString());

--- a/lib/bench.js
+++ b/lib/bench.js
@@ -1,27 +1,17 @@
 #!/usr/bin/env node
 module.exports = function (args, input, output) {
 
-  var Table = require('cli-table');
-  var HTMLTable = require('./html-table');
-  var formatRow = require('./format-row');
   var storage = require('./storage');
   var minify = require('./minify');
   var fs = require('fs');
   var path = require('path');
-  require('colors');
-
-  var lineBreak = require('os').EOL;
 
   // ARGUMENTS
   var only = args.only;
-  var asHTML = args.asHTML;
   var showTotal = args.total;
   var measureGzip = args.gzip;
 
-  var activeMinifiers = minify.getActive(only);
-
-  // RUN BENCHMARK
-  var minifierNames = activeMinifiers.slice(0).map(function(name) {
+  var activeMinifiers = minify.getActive(only).map(function(name) {
     var packageName = name.split(' ')[0];
     var packageDefinition = JSON.parse(fs.readFileSync(path.join('node_modules', packageName, 'package.json')));
     var repositoryUrl = packageDefinition.repository &&
@@ -29,63 +19,53 @@ module.exports = function (args, input, output) {
       packageDefinition.repository.url.replace(/^git:\/\//, 'https://');
     var version = packageDefinition.version;
 
-    if (asHTML && repositoryUrl)
-      return '<a href="' + repositoryUrl + '">' + name + ' - ' + version + '</a>';
-    else
-      return name + ' - ' + version;
+    return {
+      name: name,
+      version: version,
+      url: repositoryUrl,
+      results: {}
+    };
   });
-  minifierNames.unshift('');
 
-  var tableClass = asHTML ? HTMLTable : Table;
-  var results = new tableClass({ head: minifierNames });
-  var totalLength = 0;
+  var processedFiles = {};
 
   var benchmark = function(filename) {
     if (filename.indexOf('.css') == -1)
       return;
 
     var source = fs.readFileSync(path.join('data', filename), 'utf8');
-    var size = asHTML ?
-      ' - <em>' + source.length + ' bytes</em>' :
-      ' - ' + source.length + ' bytes';
-    var row = [filename + size];
-    totalLength += source.length;
+    processedFiles[filename] = {
+      size: source.length
+    };
 
-    activeMinifiers.forEach(function(name) {
+    activeMinifiers.forEach(function(minifier) {
       try {
-        var stats = minify.measure(name, source, measureGzip);
+        var stats = minify.measure(minifier.name, source, measureGzip);
 
-        storage.save(filename, name, stats);
+        storage.save(filename, minifier.name, stats);
         process.stderr.write('.');
       } catch (e) {
-        storage.save(filename, name, NaN, NaN);
+        storage.save(filename, minifier.name);
         process.stderr.write('F');
       }
+
     });
 
-    activeMinifiers.forEach(function(name) {
-      row.push(formatRow(asHTML, storage.get(filename, name), measureGzip));
+    activeMinifiers.forEach(function(minifier) {
+      minifier.results[filename] = storage.get(filename, minifier.name);
     });
-
-    results.push(row);
   };
 
 
   input.forEach(benchmark);
+  process.stderr.write('\n');
 
   if (showTotal) {
-    var totalRow = ['TOTAL - ' + (asHTML ?
-      ('<em>' + totalLength + ' bytes</em>') :
-      (totalLength + ' bytes')
-    )];
-    activeMinifiers.forEach(function(name) {
-      totalRow.push(formatRow(asHTML, storage.total(name), measureGzip));
+    activeMinifiers.forEach(function(minifier) {
+      minifier.total = storage.total(minifier.name);
     });
-    results.push(totalRow);
   }
 
-  output(lineBreak);
-  output(results.toString());
-  output(lineBreak);
+  output(processedFiles, activeMinifiers);
 
 };

--- a/lib/format-row.js
+++ b/lib/format-row.js
@@ -1,22 +1,23 @@
-module.exports = function(asHTML, result) {
+module.exports = function(asHTML, result, gzip) {
   var styled = function(value, color, bootstrapClass) {
     return asHTML ?
       { 'class': bootstrapClass, value: value } :
       value[color];
   };
 
-  if (isNaN(result.value.time))
+  if (!result.value.isValid())
     return styled('error', 'red', 'danger');
   if (typeof result == 'string')
     return result;
 
-  var value = result.value.size + ' bytes';
+  var sizeKey = gzip ? 'gzip' : 'size';
+  var value = result.value.format(sizeKey, 'byte');
   var valueStyled = value;
   var formatted = asHTML ? {} : '';
 
-  if (result.compare.size.worst)
+  if (result.compare[sizeKey].worst)
     valueStyled = styled(value, 'red', 'danger');
-  if (result.compare.size.best)
+  if (result.compare[sizeKey].best)
     valueStyled = styled(value, 'green', 'success');
 
   if (asHTML) {
@@ -26,7 +27,7 @@ module.exports = function(asHTML, result) {
   else
     formatted = valueStyled;
 
-  valueStyled = value = result.value.time + ' ms';
+  valueStyled = value = result.value.format('time', 'time');
 
   if (result.compare.time.worst)
     valueStyled = styled(value, 'red', 'danger');

--- a/lib/format-row.js
+++ b/lib/format-row.js
@@ -1,0 +1,44 @@
+module.exports = function(asHTML, result) {
+  var styled = function(value, color, bootstrapClass) {
+    return asHTML ?
+      { 'class': bootstrapClass, value: value } :
+      value[color];
+  };
+
+  if (isNaN(result.value.time))
+    return styled('error', 'red', 'danger');
+  if (typeof result == 'string')
+    return result;
+
+  var value = result.value.size + ' bytes';
+  var valueStyled = value;
+  var formatted = asHTML ? {} : '';
+
+  if (result.compare.size.worst)
+    valueStyled = styled(value, 'red', 'danger');
+  if (result.compare.size.best)
+    valueStyled = styled(value, 'green', 'success');
+
+  if (asHTML) {
+    formatted.size = valueStyled.value || value;
+    formatted.sizeClass = valueStyled.class || 'default';
+  }
+  else
+    formatted = valueStyled;
+
+  valueStyled = value = result.value.time + ' ms';
+
+  if (result.compare.time.worst)
+    valueStyled = styled(value, 'red', 'danger');
+  if (result.compare.time.best)
+    valueStyled = styled(value, 'green', 'success');
+
+  if (asHTML) {
+    formatted.time = valueStyled.value || value;
+    formatted.timeClass = valueStyled.class || 'default';
+  }
+  else
+    formatted += ' - ' + valueStyled;
+
+  return formatted;
+};

--- a/lib/format-row.js
+++ b/lib/format-row.js
@@ -1,45 +1,66 @@
-module.exports = function(asHTML, result, gzip) {
-  var styled = function(value, color, bootstrapClass) {
-    return asHTML ?
-      { 'class': bootstrapClass, value: value } :
-      value[color];
-  };
+var formats = {
+  'time': 'time',
+  'size': 'byte',
+  'gzip': 'byte'
+};
 
+var styled = function(asHTML, value, color, bootstrapClass) {
+  return asHTML ?
+    { 'class': bootstrapClass, value: value } :
+    value[color];
+};
+
+var formatValue = function (asHTML, result, key) {
+  var value = result.value.format(key, formats[key]);
+  var valueStyled = value;
+
+  if (result.compare[key].worst)
+    valueStyled = styled(asHTML, value, 'red', 'danger');
+  if (result.compare[key].best)
+    valueStyled = styled(asHTML, value, 'green', 'success');
+
+  return valueStyled;
+};
+
+module.exports = function(asHTML, result, gzip, filter) {
   if (!result.value.isValid())
-    return styled('error', 'red', 'danger');
+    return styled(asHTML, 'error', 'red', 'danger');
   if (typeof result == 'string')
     return result;
 
-  var sizeKey = gzip ? 'gzip' : 'size';
-  var value = result.value.format(sizeKey, 'byte');
-  var valueStyled = value;
+  var valueStyled;
   var formatted = asHTML ? {} : '';
 
-  if (result.compare[sizeKey].worst)
-    valueStyled = styled(value, 'red', 'danger');
-  if (result.compare[sizeKey].best)
-    valueStyled = styled(value, 'green', 'success');
+  if (!filter) {
+    var sizeKey = gzip ? 'gzip' : 'size';
+    valueStyled = formatValue(asHTML, result, sizeKey);
 
-  if (asHTML) {
-    formatted.size = valueStyled.value || value;
-    formatted.sizeClass = valueStyled.class || 'default';
+    if (asHTML) {
+      formatted.size = valueStyled.value || valueStyled;
+      formatted.sizeClass = valueStyled.class || 'default';
+    }
+    else
+      formatted = valueStyled;
+
+    valueStyled = formatValue(asHTML, result, 'time');
+
+    if (asHTML) {
+      formatted.time = valueStyled.value || valueStyled;
+      formatted.timeClass = valueStyled.class || 'default';
+    }
+    else
+      formatted += ' - ' + valueStyled;
+
+  } else {
+    valueStyled = formatValue(asHTML, result, filter);
+
+    if (asHTML) {
+      formatted.size = valueStyled.value || valueStyled;
+      formatted.sizeClass = valueStyled.class || 'default';
+    }
+    else
+      formatted = valueStyled;
   }
-  else
-    formatted = valueStyled;
-
-  valueStyled = value = result.value.format('time', 'time');
-
-  if (result.compare.time.worst)
-    valueStyled = styled(value, 'red', 'danger');
-  if (result.compare.time.best)
-    valueStyled = styled(value, 'green', 'success');
-
-  if (asHTML) {
-    formatted.time = valueStyled.value || value;
-    formatted.timeClass = valueStyled.class || 'default';
-  }
-  else
-    formatted += ' - ' + valueStyled;
 
   return formatted;
 };

--- a/lib/html-table.js
+++ b/lib/html-table.js
@@ -17,8 +17,8 @@ module.exports = function(options) {
           body.push(tag.replace('>', ' class="' + value.class + '">') + value.value + endTag);
         }
         else {
-          var size = '<span class="label label-' + value.sizeClass + '">' + value.size + '</span>';
-          var time = '<span class="label label-' + value.timeClass + '">' + value.time + '</span>';
+          var size = value.size ? '<span class="label label-' + value.sizeClass + '">' + value.size + '</span>' : '';
+          var time = value.time ? '<span class="label label-' + value.timeClass + '">' + value.time + '</span>' : '';
           body.push(tag + size + '<br>' + time + endTag);
         }
       }

--- a/lib/measure.js
+++ b/lib/measure.js
@@ -1,0 +1,44 @@
+function isFloat (n) {
+  return n === +n && n !== (n|0);
+}
+
+var metrics = ['time', 'size', 'gzip'];
+var Measure = function (stats) {
+  this.each(function (key) {
+    this[key] = stats[key];
+  });
+};
+
+Measure.prototype.each = function (fn) {
+  metrics.forEach(fn, this);
+};
+
+Measure.prototype.add = function (stats) {
+  this.each(function (key) {
+    this[key] += stats[key];
+  });
+};
+
+Measure.prototype.isValid = function () {
+  return ('time' in this) && !isNaN(this.time);
+};
+
+Measure.prototype.equal = function (key, measure) {
+  return this[key] == measure[key];
+};
+
+Measure.prototype.format = function (key, type) {
+  var value = this[key];
+  if (isFloat(value)){
+    value = Number(value.toFixed(2));
+  }
+
+  if (type === 'byte') {
+    return value + ' bytes';
+  }
+  if (type === 'time') {
+    return value + ' ms';
+  }
+};
+
+module.exports = Measure;

--- a/lib/measure.js
+++ b/lib/measure.js
@@ -2,10 +2,10 @@ function isFloat (n) {
   return n === +n && n !== (n|0);
 }
 
-var metrics = ['time', 'size', 'gzip'];
+var metrics = ['time', 'size', 'gzip', 'original'];
 var Measure = function (stats) {
   this.each(function (key) {
-    this[key] = stats[key];
+    this[key] = stats ? stats[key] : NaN;
   });
 };
 
@@ -15,7 +15,7 @@ Measure.prototype.each = function (fn) {
 
 Measure.prototype.add = function (stats) {
   this.each(function (key) {
-    this[key] += stats[key];
+    this[key] += stats ? stats[key] : NaN;
   });
 };
 

--- a/lib/minify.js
+++ b/lib/minify.js
@@ -1,0 +1,61 @@
+var CleanCSS = require('clean-css');
+var cssCondense = require('css-condense');
+var csso = require('csso');
+var cssshrink = require('cssshrink');
+var csswring = require('csswring');
+var moreCss = require('more-css');
+var ncss = require('ncss');
+var sqwish = require('sqwish');
+var ycssmin = require('ycssmin');
+
+var gzipSize = require('gzip-size');
+
+// MINIFIERS
+var minifiers = {
+'clean-css': function(source) {
+  return new CleanCSS({ processImport: false }).minify(source).styles;
+},
+'clean-css (advanced off)': function(source) {
+  return new CleanCSS({ advanced: false, processImport: false }).minify(source).styles;
+},
+'css-condense': function(source) {
+  return cssCondense.compress(source, { safe: true });
+},
+'csso': csso.justDoIt,
+'csso (reordering off)': function(source) {
+  return csso.justDoIt(source, true);
+},
+'cssshrink': cssshrink.shrink,
+'csswring': function (source) {
+  return csswring.wring(source).css;
+},
+'more-css': function(source) {
+  return moreCss.compress(source, true);
+},
+'ncss': ncss,
+'sqwish': sqwish.minify,
+'ycssmin': ycssmin.cssmin
+};
+
+exports.getActive = function (only) {
+  var activeMinifiers = [];
+  for (var name in minifiers) {
+    if (only.test(name))
+      activeMinifiers.push(name);
+  }
+  return activeMinifiers;
+};
+
+exports.measure = function (minifierName, source, gzip) {
+  var start = process.hrtime();
+  var minified = minifiers[minifierName](source);
+  var itTook = process.hrtime(start);
+  var took = Math.round((1000 * itTook[0] + itTook[1] / 1000000) * 100) / 100;
+  var gzipped = gzip ? gzipSize.sync(minified) : NaN;
+
+  return {
+    time: took,
+    size: minified.length,
+    gzip: gzipped
+  };
+};

--- a/lib/minify.js
+++ b/lib/minify.js
@@ -55,6 +55,7 @@ exports.measure = function (minifierName, source, gzip) {
 
   return {
     time: took,
+    original: source.length,
     size: minified.length,
     gzip: gzipped
   };

--- a/lib/process-output.js
+++ b/lib/process-output.js
@@ -1,0 +1,79 @@
+// mock it to drop output from ncss
+var output = process.stdout.write.bind(process.stdout);
+process.stdout.write = function() {};
+
+require('colors');
+
+var Table = require('cli-table');
+var HTMLTable = require('./html-table');
+var formatRow = require('./format-row');
+
+var lineBreak = require('os').EOL;
+var tableHeadings = {
+  'size': 'File size',
+  'time': 'Time',
+  'gzip': 'Gzip size'
+};
+
+var write = function (processedFiles, activeMinifiers, asHTML, measureGzip, showTotal, filter) {
+  output(lineBreak);
+
+  var minifierNames = activeMinifiers.slice(0).map(function (minifier) {
+    if (asHTML && minifier.url)
+      return '<a href="' + minifier.url + '">' + minifier.name + ' - ' + minifier.version + '</a>';
+    else
+      return minifier.name + ' - ' + minifier.version;
+  });
+  minifierNames.unshift(tableHeadings[filter] || '');
+
+  var tableClass = asHTML ? HTMLTable : Table;
+  var results = new tableClass({ head: minifierNames });
+  var totalLength = 0;
+
+  Object.keys(processedFiles).forEach(function (filename) {
+    var fileSize = processedFiles[filename].size;
+    var size = asHTML ?
+      ' - <em>' + fileSize + ' bytes</em>' :
+      ' - ' + fileSize + ' bytes';
+    totalLength += fileSize;
+    
+    var row = [filename + size];
+
+    activeMinifiers.forEach(function(minifier) {
+      row.push(formatRow(asHTML, minifier.results[filename], measureGzip, filter));
+    });
+
+    results.push(row);
+  });
+
+  if (showTotal) {
+    var totalRow = ['TOTAL - ' + (asHTML ?
+      ('<em>' + totalLength + ' bytes</em>') :
+      (totalLength + ' bytes')
+    )];
+    activeMinifiers.forEach(function(minifier) {
+      totalRow.push(formatRow(asHTML, minifier.total, measureGzip, filter));
+    });
+
+    results.push(totalRow);
+  }
+
+  output(results.toString());
+  output(lineBreak);
+
+};
+
+exports.getOutput = function (asHTML, measureGzip, total, verbose) {
+  return function (files, results) {
+    if (verbose) {
+      ['time', 'size'].forEach(function (filter) {
+        write(files, results, asHTML, measureGzip, total, filter);
+      });
+      if (measureGzip) {
+        write(files, results, asHTML, measureGzip, total, 'gzip');
+      }
+    } else {
+      write(files, results, asHTML, measureGzip, total);
+    }
+  };
+};

--- a/lib/storage.js
+++ b/lib/storage.js
@@ -1,3 +1,5 @@
+var Measure = require('./measure');
+
 var allResults = {};
 var totals = {};
 
@@ -6,53 +8,46 @@ var comparator = function(a, b) {
 };
 
 var compareResult = function (result, against) {
-  var sizes = against.slice().sort(comparator.bind({key: 'size'}));
-  var times = against.slice().sort(comparator.bind({key: 'time'}));
-  var compare = {
-    size: {
+  var compare = {};
+
+  result.each(function (key) {
+    compare[key] = {
       best: false,
       worst: false
-    },
-    time: {
-      best: false,
-      worst: false
+    };
+
+    var sorted = against.slice().sort(comparator.bind({key: key}));
+    var howMany = sorted.length;
+
+    if (howMany > 1 && result.equal(key, sorted[howMany - 1]) && !result.equal(key, sorted[0])) {
+      compare[key].worst = true;
     }
-  };
-
-  if (result.size == sizes[sizes.length - 1].size && sizes.length > 1 && sizes[0].size != sizes[sizes.length - 1].size)
-    compare.size.worst = true;
-  if (result.size == sizes[0].size)
-    compare.size.best = true;
-
-  if (result.time == times[times.length - 1].time && times.length > 1 && times[0].time != times[times.length - 1].time)
-    compare.time.worst = true;
-  if (result.time == times[0].time)
-    compare.time.best = true;
+    if (howMany && result.equal(key, sorted[0])) {
+      compare[key].best = true;
+    }
+  });
 
   return compare;
 };
 
-exports.save = function (file, minifier, size, time) {
+exports.save = function (file, minifier, stats) {
   if (!allResults[file]) {
     allResults[file] = {};
   }
-  allResults[file][minifier] = {
-    size: size,
-    time: time
-  };
+  allResults[file][minifier] = new Measure(stats);
 
   if (!totals[minifier]) {
-    totals[minifier] = { size: 0, time: 0 };
+    totals[minifier] = new Measure(stats);
+  } else {
+    totals[minifier].add(stats);
   }
-  totals[minifier].size += size;
-  totals[minifier].time += time;
 };
 
 exports.get = function (file, minifier) {
   var against = [];
   for (var name in allResults[file]) {
     var value = allResults[file][name];
-    if (!isNaN(value.time)) {
+    if (value.isValid()) {
       against.push(value);
     }
   }
@@ -69,18 +64,14 @@ exports.total = function (minifier) {
   var against = [];
   for (var name in totals) {
     var value = totals[name];
-    if (!isNaN(value.time)) {
+    if (value.isValid()) {
       against.push(value);
     }
   }
   var result = totals[minifier];
 
   return {
-    value: {
-      size: result.size,
-      // Because math with float values is weird
-      time: Number(result.time.toFixed(2))
-    },
+    value: result,
     compare: compareResult(result, against)
   };
 };

--- a/lib/storage.js
+++ b/lib/storage.js
@@ -1,0 +1,86 @@
+var allResults = {};
+var totals = {};
+
+var comparator = function(a, b) {
+  return a[this.key] > b[this.key] ? 1 : -1;
+};
+
+var compareResult = function (result, against) {
+  var sizes = against.slice().sort(comparator.bind({key: 'size'}));
+  var times = against.slice().sort(comparator.bind({key: 'time'}));
+  var compare = {
+    size: {
+      best: false,
+      worst: false
+    },
+    time: {
+      best: false,
+      worst: false
+    }
+  };
+
+  if (result.size == sizes[sizes.length - 1].size && sizes.length > 1 && sizes[0].size != sizes[sizes.length - 1].size)
+    compare.size.worst = true;
+  if (result.size == sizes[0].size)
+    compare.size.best = true;
+
+  if (result.time == times[times.length - 1].time && times.length > 1 && times[0].time != times[times.length - 1].time)
+    compare.time.worst = true;
+  if (result.time == times[0].time)
+    compare.time.best = true;
+
+  return compare;
+};
+
+exports.save = function (file, minifier, size, time) {
+  if (!allResults[file]) {
+    allResults[file] = {};
+  }
+  allResults[file][minifier] = {
+    size: size,
+    time: time
+  };
+
+  if (!totals[minifier]) {
+    totals[minifier] = { size: 0, time: 0 };
+  }
+  totals[minifier].size += size;
+  totals[minifier].time += time;
+};
+
+exports.get = function (file, minifier) {
+  var against = [];
+  for (var name in allResults[file]) {
+    var value = allResults[file][name];
+    if (!isNaN(value.time)) {
+      against.push(value);
+    }
+  }
+
+  var result = allResults[file][minifier];
+
+  return {
+    value: result,
+    compare: compareResult(result, against)
+  };
+};
+
+exports.total = function (minifier) {
+  var against = [];
+  for (var name in totals) {
+    var value = totals[name];
+    if (!isNaN(value.time)) {
+      against.push(value);
+    }
+  }
+  var result = totals[minifier];
+
+  return {
+    value: {
+      size: result.size,
+      // Because math with float values is weird
+      time: Number(result.time.toFixed(2))
+    },
+    compare: compareResult(result, against)
+  };
+};

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "bench": "node ./bin/bench --html>index.html",
     "check": "jshint ./bin/bench ."
   },
+  "main": "lib/bench.js",
   "devDependencies": {
     "clean-css": "3.0.x",
     "cli-table": "0.3.x",

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "csso": "1.3.x",
     "cssshrink": "0.0.x",
     "csswring": "2.0.x",
+    "gzip-size": "1.0.x",
     "jshint": "2.5.x",
     "more-css": "0.8.x",
     "ncss": "1.1.x",


### PR DESCRIPTION
When using `--verbose`, tables are split, this should allow sorting and adding percentages.

It also changes the module organization, so it's easier for other modules to access the result object.

I'll add percentages in another pull request.
