### PR TITLE
Always load bootstrap CSS via HTTPS

### DIFF
--- a/index.html
+++ b/index.html
@@ -5,7 +5,7 @@
 <meta charset="utf-8">
 <title>css-minification-benchmark results</title>
 <meta name="viewport" content="width=device-width, initial-scale=1">
-<link rel="stylesheet" href="http://maxcdn.bootstrapcdn.com/bootstrap/3.3.4/css/bootstrap.min.css">
+<link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.4/css/bootstrap.min.css">
 <style>th{text-align:center;vertical-align:middle!important}</style>
 </head>
 <body>

--- a/lib/html-table.js
+++ b/lib/html-table.js
@@ -34,7 +34,7 @@ module.exports = function(options) {
     page.push('<meta charset="utf-8">');
     page.push('<title>css-minification-benchmark results</title>');
     page.push('<meta name="viewport" content="width=device-width, initial-scale=1">');
-    page.push('<link rel="stylesheet" href="http://maxcdn.bootstrapcdn.com/bootstrap/3.3.4/css/bootstrap.min.css">');
+    page.push('<link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.4/css/bootstrap.min.css">');
     page.push('<style>th{text-align:center;vertical-align:middle!important}</style>');
     page.push('</head>');
     page.push('<body>');


### PR DESCRIPTION
When we [open the Github page via https](https://goalsmashers.github.io/css-minification-benchmark/), the page fails to get the stylesheet because it is loaded via http.

(DevTool error message on Chrome)

```
Mixed Content: The page at 'https://goalsmashers.github.io/css-minification-benchmark/' was loaded over HTTPS, but requested an insecure stylesheet 'http://maxcdn.bootstrapcdn.com/bootstrap/3.3.4/css/bootstrap.min.css'. This request has been blocked; the content must be served over HTTPS.
```

And also: [Web Security: Why You Should Always Use HTTPS](http://mashable.com/2011/05/31/https-web-security/)
