### PR TITLE
Replace `@parcel/css` with `lightningcss`

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ A comparison of CSS minification engines.
 * [cssnano](https://github.com/ben-eb/cssnano)
 * [csso](https://github.com/css/csso)
 * [esbuild](https://github.com/evanw/esbuild)
+* [lightningcss](https://github.com/parcel-bundler/lightningcss)
 
 ### How can I see the results?
 

--- a/lib/minify.js
+++ b/lib/minify.js
@@ -11,7 +11,7 @@ const cssnano = require('cssnano');
 const csso = require('csso');
 const gzipSize = require('gzip-size');
 const esbuild = require('esbuild');
-const parcelCss = require('@parcel/css');
+const lightningcss = require('lightningcss');
 
 // MINIFIERS
 const minifiers = {
@@ -40,8 +40,8 @@ const minifiers = {
   'esbuild': source => {
     return esbuild.transformSync(source, { loader: 'css', minify: true }).code;
   },
-  '@parcel/css': source => {
-    return parcelCss.transform({ filename: '', code: Buffer.from(source), minify: true }).code;
+  'lightningcss': source => {
+    return lightningcss.transform({ filename: '', code: Buffer.from(source), minify: true }).code;
   }
 };
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,13 +12,13 @@
         "css-minification-benchmark": "bin/bench.js"
       },
       "devDependencies": {
-        "@parcel/css": "^1.0.1",
         "clean-css": "^5.2.2",
         "cssnano": "^5.0.15",
         "cssnano-preset-advanced": "^5.1.10",
         "csso": "^5.0.2",
         "esbuild": "^0.14.11",
         "gzip-size": "^6.0.0",
+        "lightningcss": "^1.17.1",
         "picocolors": "^1.0.0",
         "postcss": "^8.4.5",
         "q": "^1.5.1",
@@ -592,192 +592,6 @@
       },
       "engines": {
         "node": ">= 8"
-      }
-    },
-    "node_modules/@parcel/css": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@parcel/css/-/css-1.0.1.tgz",
-      "integrity": "sha512-6LBly89WO8uzUHA2Jh2harvu9ok3nylaNgj7m+ql+BWWYO0ILTAZc8zelWTy8xKgEnqVHF27drVvwdTAPIs1Bw==",
-      "dev": true,
-      "dependencies": {
-        "detect-libc": "^1.0.3"
-      },
-      "engines": {
-        "node": ">= 12.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/parcel"
-      },
-      "optionalDependencies": {
-        "@parcel/css-darwin-arm64": "^1.0.1",
-        "@parcel/css-darwin-x64": "^1.0.1",
-        "@parcel/css-linux-arm-gnueabihf": "^1.0.1",
-        "@parcel/css-linux-arm64-gnu": "^1.0.1",
-        "@parcel/css-linux-arm64-musl": "^1.0.1",
-        "@parcel/css-linux-x64-gnu": "^1.0.1",
-        "@parcel/css-linux-x64-musl": "^1.0.1",
-        "@parcel/css-win32-x64-msvc": "^1.0.1"
-      }
-    },
-    "node_modules/@parcel/css-darwin-arm64": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@parcel/css-darwin-arm64/-/css-darwin-arm64-1.0.1.tgz",
-      "integrity": "sha512-6Ruuvi1hKYNQtz3j82OpJt2LwAb5kHWTXJZAsrVSa0Kbh+RMlvArd0mfca0ySZQ9tkprAFzo2Kj9Jmn9MU97Jg==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "engines": {
-        "node": ">= 12.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/parcel"
-      }
-    },
-    "node_modules/@parcel/css-darwin-x64": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@parcel/css-darwin-x64/-/css-darwin-x64-1.0.1.tgz",
-      "integrity": "sha512-FxE32rSwFihAzGbcmmUYbZmzjsFdKge9AuvOM3RiqPXDcfqd2qUCP65BUDZXfXSQzg/2dfGd3coQlDgiocXaLw==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "engines": {
-        "node": ">= 12.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/parcel"
-      }
-    },
-    "node_modules/@parcel/css-linux-arm-gnueabihf": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@parcel/css-linux-arm-gnueabihf/-/css-linux-arm-gnueabihf-1.0.1.tgz",
-      "integrity": "sha512-7678hSQXsHmTcheCJ748dsv/G/Yc0oPsoxzIHjFL4IgH8ro/aw2eYTA/qxcZYX508CZujV6y4pUjl1RVB0FGRw==",
-      "cpu": [
-        "arm"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">= 12.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/parcel"
-      }
-    },
-    "node_modules/@parcel/css-linux-arm64-gnu": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@parcel/css-linux-arm64-gnu/-/css-linux-arm64-gnu-1.0.1.tgz",
-      "integrity": "sha512-RSDpBtMZquQn0frr7Txrj4/Fn2vtCiimlF3qFo1KC58e3Su91nYx/nUQ3zi2ST1YeDoTyDwdOvlkFsA2OSyP0g==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">= 12.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/parcel"
-      }
-    },
-    "node_modules/@parcel/css-linux-arm64-musl": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@parcel/css-linux-arm64-musl/-/css-linux-arm64-musl-1.0.1.tgz",
-      "integrity": "sha512-kJS1nMwvW60muNSr/Rv/2VL/9LvhnD5ZgFF7dnY44tHOCNvSQmV9n4kll1CtRPzV0SSW+8E9r9YeXGxoVSn45Q==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">= 12.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/parcel"
-      }
-    },
-    "node_modules/@parcel/css-linux-x64-gnu": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@parcel/css-linux-x64-gnu/-/css-linux-x64-gnu-1.0.1.tgz",
-      "integrity": "sha512-ZXsQEvpFiy/olpzXfoSspMZtdj/GBuTUvJ9aMUsWfPuo6ulWUpAn8lJFJcY4YIWqR+7mb0F44UdWDSfEbpjJig==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">= 12.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/parcel"
-      }
-    },
-    "node_modules/@parcel/css-linux-x64-musl": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@parcel/css-linux-x64-musl/-/css-linux-x64-musl-1.0.1.tgz",
-      "integrity": "sha512-ar6fNPA9+MyCktJKOrDLnLgOOiig1vld8sTmk769XvTVsHtkt+4csrzNHgNxb8G7wbeZqg6Qrx4rcbfpWkz3vA==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">= 12.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/parcel"
-      }
-    },
-    "node_modules/@parcel/css-win32-x64-msvc": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@parcel/css-win32-x64-msvc/-/css-win32-x64-msvc-1.0.1.tgz",
-      "integrity": "sha512-JvkrhnDdcZgDYgqwAzbj/sAeEekN7bqylTi321ZRlyr+ldEHMnJJWB0m9sJ/KUvIAIunG12j0NJ84mqEYosSgA==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "engines": {
-        "node": ">= 12.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/parcel"
       }
     },
     "node_modules/@trysound/sax": {
@@ -1825,7 +1639,7 @@
     "node_modules/detect-libc": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-1.0.3.tgz",
-      "integrity": "sha1-+hN8S9aY7fVc1c0CrFWfkaTEups=",
+      "integrity": "sha512-pGjwhsmsp4kL2RTz08wcOlGN83otlqHeD/Z5T8GXZB+/YcpQ/dgo+lbU8ZsGxV0HIvqqxo9l7mqYwyYMD9bKDg==",
       "dev": true,
       "bin": {
         "detect-libc": "bin/detect-libc.js"
@@ -4235,6 +4049,192 @@
       },
       "engines": {
         "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/lightningcss": {
+      "version": "1.17.1",
+      "resolved": "https://registry.npmjs.org/lightningcss/-/lightningcss-1.17.1.tgz",
+      "integrity": "sha512-DwwM/YYqGwLLP3he41wzDXT/m+8jdEZ80i9ViQNLRgyhey3Vm6N7XHn+4o3PY6wSnVT23WLuaROIpbpIVTNOjg==",
+      "dev": true,
+      "dependencies": {
+        "detect-libc": "^1.0.3"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      },
+      "optionalDependencies": {
+        "lightningcss-darwin-arm64": "1.17.1",
+        "lightningcss-darwin-x64": "1.17.1",
+        "lightningcss-linux-arm-gnueabihf": "1.17.1",
+        "lightningcss-linux-arm64-gnu": "1.17.1",
+        "lightningcss-linux-arm64-musl": "1.17.1",
+        "lightningcss-linux-x64-gnu": "1.17.1",
+        "lightningcss-linux-x64-musl": "1.17.1",
+        "lightningcss-win32-x64-msvc": "1.17.1"
+      }
+    },
+    "node_modules/lightningcss-darwin-arm64": {
+      "version": "1.17.1",
+      "resolved": "https://registry.npmjs.org/lightningcss-darwin-arm64/-/lightningcss-darwin-arm64-1.17.1.tgz",
+      "integrity": "sha512-YTAHEy4XlzI3sMbUVjbPi9P7+N7lGcgl2JhCZhiQdRAEKnZLQch8kb5601sgESxdGXjgei7JZFqi/vVEk81wYg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-darwin-x64": {
+      "version": "1.17.1",
+      "resolved": "https://registry.npmjs.org/lightningcss-darwin-x64/-/lightningcss-darwin-x64-1.17.1.tgz",
+      "integrity": "sha512-UhXPUS2+yTTf5sXwUV0+8QY2x0bPGLgC/uhcknWSQMqWn1zGty4fFvH04D7f7ij0ujwSuN+Q0HtU7lgmMrPz0A==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-arm-gnueabihf": {
+      "version": "1.17.1",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm-gnueabihf/-/lightningcss-linux-arm-gnueabihf-1.17.1.tgz",
+      "integrity": "sha512-alUZumuznB6K/9yZ0zuZkODXUm8uRnvs9t0CL46CXN16Y2h4gOx5ahUCMlelUb7inZEsgJIoepgLsJzBUrSsBw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-arm64-gnu": {
+      "version": "1.17.1",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-gnu/-/lightningcss-linux-arm64-gnu-1.17.1.tgz",
+      "integrity": "sha512-/1XaH2cOjDt+ivmgfmVFUYCA0MtfNWwtC4P8qVi53zEQ7P8euyyZ1ynykZOyKXW9Q0DzrwcLTh6+hxVLcbtGBg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-arm64-musl": {
+      "version": "1.17.1",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-musl/-/lightningcss-linux-arm64-musl-1.17.1.tgz",
+      "integrity": "sha512-/IgE7lYWFHCCQFTMIwtt+fXLcVOha8rcrNze1JYGPWNorO6NBc6MJo5u5cwn5qMMSz9fZCCDIlBBU4mGwjQszQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-x64-gnu": {
+      "version": "1.17.1",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-gnu/-/lightningcss-linux-x64-gnu-1.17.1.tgz",
+      "integrity": "sha512-OyE802IAp4DB9vZrHlOyWunbHLM9dN08tJIKN/HhzzLKIHizubOWX6NMzUXMZLsaUrYwVAHHdyEA+712p8mMzA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-x64-musl": {
+      "version": "1.17.1",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-musl/-/lightningcss-linux-x64-musl-1.17.1.tgz",
+      "integrity": "sha512-ydwGgV3Usba5P53RAOqCA9MsRsbb8jFIEVhf7/BXFjpKNoIQyijVTXhwIgQr/oGwUNOHfgQ3F8ruiUjX/p2YKw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-win32-x64-msvc": {
+      "version": "1.17.1",
+      "resolved": "https://registry.npmjs.org/lightningcss-win32-x64-msvc/-/lightningcss-win32-x64-msvc-1.17.1.tgz",
+      "integrity": "sha512-Ngqtx9NazaiAOk71XWwSsqgAuwYF+8PO6UYsoU7hAukdrSS98kwaBMEDw1igeIiZy1XD/4kh5KVnkjNf7ZOxVQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
       }
     },
     "node_modules/lilconfig": {
@@ -8163,79 +8163,6 @@
         "fastq": "^1.6.0"
       }
     },
-    "@parcel/css": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@parcel/css/-/css-1.0.1.tgz",
-      "integrity": "sha512-6LBly89WO8uzUHA2Jh2harvu9ok3nylaNgj7m+ql+BWWYO0ILTAZc8zelWTy8xKgEnqVHF27drVvwdTAPIs1Bw==",
-      "dev": true,
-      "requires": {
-        "@parcel/css-darwin-arm64": "^1.0.1",
-        "@parcel/css-darwin-x64": "^1.0.1",
-        "@parcel/css-linux-arm-gnueabihf": "^1.0.1",
-        "@parcel/css-linux-arm64-gnu": "^1.0.1",
-        "@parcel/css-linux-arm64-musl": "^1.0.1",
-        "@parcel/css-linux-x64-gnu": "^1.0.1",
-        "@parcel/css-linux-x64-musl": "^1.0.1",
-        "@parcel/css-win32-x64-msvc": "^1.0.1",
-        "detect-libc": "^1.0.3"
-      }
-    },
-    "@parcel/css-darwin-arm64": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@parcel/css-darwin-arm64/-/css-darwin-arm64-1.0.1.tgz",
-      "integrity": "sha512-6Ruuvi1hKYNQtz3j82OpJt2LwAb5kHWTXJZAsrVSa0Kbh+RMlvArd0mfca0ySZQ9tkprAFzo2Kj9Jmn9MU97Jg==",
-      "dev": true,
-      "optional": true
-    },
-    "@parcel/css-darwin-x64": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@parcel/css-darwin-x64/-/css-darwin-x64-1.0.1.tgz",
-      "integrity": "sha512-FxE32rSwFihAzGbcmmUYbZmzjsFdKge9AuvOM3RiqPXDcfqd2qUCP65BUDZXfXSQzg/2dfGd3coQlDgiocXaLw==",
-      "dev": true,
-      "optional": true
-    },
-    "@parcel/css-linux-arm-gnueabihf": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@parcel/css-linux-arm-gnueabihf/-/css-linux-arm-gnueabihf-1.0.1.tgz",
-      "integrity": "sha512-7678hSQXsHmTcheCJ748dsv/G/Yc0oPsoxzIHjFL4IgH8ro/aw2eYTA/qxcZYX508CZujV6y4pUjl1RVB0FGRw==",
-      "dev": true,
-      "optional": true
-    },
-    "@parcel/css-linux-arm64-gnu": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@parcel/css-linux-arm64-gnu/-/css-linux-arm64-gnu-1.0.1.tgz",
-      "integrity": "sha512-RSDpBtMZquQn0frr7Txrj4/Fn2vtCiimlF3qFo1KC58e3Su91nYx/nUQ3zi2ST1YeDoTyDwdOvlkFsA2OSyP0g==",
-      "dev": true,
-      "optional": true
-    },
-    "@parcel/css-linux-arm64-musl": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@parcel/css-linux-arm64-musl/-/css-linux-arm64-musl-1.0.1.tgz",
-      "integrity": "sha512-kJS1nMwvW60muNSr/Rv/2VL/9LvhnD5ZgFF7dnY44tHOCNvSQmV9n4kll1CtRPzV0SSW+8E9r9YeXGxoVSn45Q==",
-      "dev": true,
-      "optional": true
-    },
-    "@parcel/css-linux-x64-gnu": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@parcel/css-linux-x64-gnu/-/css-linux-x64-gnu-1.0.1.tgz",
-      "integrity": "sha512-ZXsQEvpFiy/olpzXfoSspMZtdj/GBuTUvJ9aMUsWfPuo6ulWUpAn8lJFJcY4YIWqR+7mb0F44UdWDSfEbpjJig==",
-      "dev": true,
-      "optional": true
-    },
-    "@parcel/css-linux-x64-musl": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@parcel/css-linux-x64-musl/-/css-linux-x64-musl-1.0.1.tgz",
-      "integrity": "sha512-ar6fNPA9+MyCktJKOrDLnLgOOiig1vld8sTmk769XvTVsHtkt+4csrzNHgNxb8G7wbeZqg6Qrx4rcbfpWkz3vA==",
-      "dev": true,
-      "optional": true
-    },
-    "@parcel/css-win32-x64-msvc": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@parcel/css-win32-x64-msvc/-/css-win32-x64-msvc-1.0.1.tgz",
-      "integrity": "sha512-JvkrhnDdcZgDYgqwAzbj/sAeEekN7bqylTi321ZRlyr+ldEHMnJJWB0m9sJ/KUvIAIunG12j0NJ84mqEYosSgA==",
-      "dev": true,
-      "optional": true
-    },
     "@trysound/sax": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/@trysound/sax/-/sax-0.2.0.tgz",
@@ -9047,7 +8974,7 @@
     "detect-libc": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-1.0.3.tgz",
-      "integrity": "sha1-+hN8S9aY7fVc1c0CrFWfkaTEups=",
+      "integrity": "sha512-pGjwhsmsp4kL2RTz08wcOlGN83otlqHeD/Z5T8GXZB+/YcpQ/dgo+lbU8ZsGxV0HIvqqxo9l7mqYwyYMD9bKDg==",
       "dev": true
     },
     "dir-glob": {
@@ -10770,6 +10697,79 @@
         "prelude-ls": "^1.2.1",
         "type-check": "~0.4.0"
       }
+    },
+    "lightningcss": {
+      "version": "1.17.1",
+      "resolved": "https://registry.npmjs.org/lightningcss/-/lightningcss-1.17.1.tgz",
+      "integrity": "sha512-DwwM/YYqGwLLP3he41wzDXT/m+8jdEZ80i9ViQNLRgyhey3Vm6N7XHn+4o3PY6wSnVT23WLuaROIpbpIVTNOjg==",
+      "dev": true,
+      "requires": {
+        "detect-libc": "^1.0.3",
+        "lightningcss-darwin-arm64": "1.17.1",
+        "lightningcss-darwin-x64": "1.17.1",
+        "lightningcss-linux-arm-gnueabihf": "1.17.1",
+        "lightningcss-linux-arm64-gnu": "1.17.1",
+        "lightningcss-linux-arm64-musl": "1.17.1",
+        "lightningcss-linux-x64-gnu": "1.17.1",
+        "lightningcss-linux-x64-musl": "1.17.1",
+        "lightningcss-win32-x64-msvc": "1.17.1"
+      }
+    },
+    "lightningcss-darwin-arm64": {
+      "version": "1.17.1",
+      "resolved": "https://registry.npmjs.org/lightningcss-darwin-arm64/-/lightningcss-darwin-arm64-1.17.1.tgz",
+      "integrity": "sha512-YTAHEy4XlzI3sMbUVjbPi9P7+N7lGcgl2JhCZhiQdRAEKnZLQch8kb5601sgESxdGXjgei7JZFqi/vVEk81wYg==",
+      "dev": true,
+      "optional": true
+    },
+    "lightningcss-darwin-x64": {
+      "version": "1.17.1",
+      "resolved": "https://registry.npmjs.org/lightningcss-darwin-x64/-/lightningcss-darwin-x64-1.17.1.tgz",
+      "integrity": "sha512-UhXPUS2+yTTf5sXwUV0+8QY2x0bPGLgC/uhcknWSQMqWn1zGty4fFvH04D7f7ij0ujwSuN+Q0HtU7lgmMrPz0A==",
+      "dev": true,
+      "optional": true
+    },
+    "lightningcss-linux-arm-gnueabihf": {
+      "version": "1.17.1",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm-gnueabihf/-/lightningcss-linux-arm-gnueabihf-1.17.1.tgz",
+      "integrity": "sha512-alUZumuznB6K/9yZ0zuZkODXUm8uRnvs9t0CL46CXN16Y2h4gOx5ahUCMlelUb7inZEsgJIoepgLsJzBUrSsBw==",
+      "dev": true,
+      "optional": true
+    },
+    "lightningcss-linux-arm64-gnu": {
+      "version": "1.17.1",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-gnu/-/lightningcss-linux-arm64-gnu-1.17.1.tgz",
+      "integrity": "sha512-/1XaH2cOjDt+ivmgfmVFUYCA0MtfNWwtC4P8qVi53zEQ7P8euyyZ1ynykZOyKXW9Q0DzrwcLTh6+hxVLcbtGBg==",
+      "dev": true,
+      "optional": true
+    },
+    "lightningcss-linux-arm64-musl": {
+      "version": "1.17.1",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-musl/-/lightningcss-linux-arm64-musl-1.17.1.tgz",
+      "integrity": "sha512-/IgE7lYWFHCCQFTMIwtt+fXLcVOha8rcrNze1JYGPWNorO6NBc6MJo5u5cwn5qMMSz9fZCCDIlBBU4mGwjQszQ==",
+      "dev": true,
+      "optional": true
+    },
+    "lightningcss-linux-x64-gnu": {
+      "version": "1.17.1",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-gnu/-/lightningcss-linux-x64-gnu-1.17.1.tgz",
+      "integrity": "sha512-OyE802IAp4DB9vZrHlOyWunbHLM9dN08tJIKN/HhzzLKIHizubOWX6NMzUXMZLsaUrYwVAHHdyEA+712p8mMzA==",
+      "dev": true,
+      "optional": true
+    },
+    "lightningcss-linux-x64-musl": {
+      "version": "1.17.1",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-musl/-/lightningcss-linux-x64-musl-1.17.1.tgz",
+      "integrity": "sha512-ydwGgV3Usba5P53RAOqCA9MsRsbb8jFIEVhf7/BXFjpKNoIQyijVTXhwIgQr/oGwUNOHfgQ3F8ruiUjX/p2YKw==",
+      "dev": true,
+      "optional": true
+    },
+    "lightningcss-win32-x64-msvc": {
+      "version": "1.17.1",
+      "resolved": "https://registry.npmjs.org/lightningcss-win32-x64-msvc/-/lightningcss-win32-x64-msvc-1.17.1.tgz",
+      "integrity": "sha512-Ngqtx9NazaiAOk71XWwSsqgAuwYF+8PO6UYsoU7hAukdrSS98kwaBMEDw1igeIiZy1XD/4kh5KVnkjNf7ZOxVQ==",
+      "dev": true,
+      "optional": true
     },
     "lilconfig": {
       "version": "2.0.4",

--- a/package.json
+++ b/package.json
@@ -29,15 +29,14 @@
     "css-minification-benchmark": "bin/bench.js"
   },
   "main": "lib/index.js",
-  "dependencies": {},
   "devDependencies": {
-    "@parcel/css": "^1.0.1",
     "clean-css": "^5.2.2",
     "cssnano": "^5.0.15",
     "cssnano-preset-advanced": "^5.1.10",
     "csso": "^5.0.2",
     "esbuild": "^0.14.11",
     "gzip-size": "^6.0.0",
+    "lightningcss": "^1.17.1",
     "picocolors": "^1.0.0",
     "postcss": "^8.4.5",
     "q": "^1.5.1",


### PR DESCRIPTION
Parcel CSS has been renamed Lightning CSS since v1.14.0. See: https://github.com/parcel-bundler/lightningcss/releases/tag/v1.14.0

And I added the missing entry in the "Which engines are covered?" section.