### PR TITLE
add `@csstools/postcss-minify`

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ A comparison of CSS minification engines.
 * [cssnano](https://github.com/ben-eb/cssnano)
 * [csso](https://github.com/css/csso)
 * [esbuild](https://github.com/evanw/esbuild)
+* [@csstools/postcss-minify](https://github.com/csstools/postcss-plugins/tree/main/plugins/postcss-minify)
 
 ### How can I see the results?
 

--- a/docs/index.html
+++ b/docs/index.html
@@ -26,161 +26,175 @@
 <th>csso (restructure off) - 5.0.2</th>
 <th>esbuild - 0.14.11</th>
 <th><a href="https://github.com/parcel-bundler/parcel-css">@parcel/css - 1.0.1</a></th>
+<th><a href="https://github.com/csstools/postcss-plugins">@csstools/postcss-minify - 1.0.0</a></th>
 </tr>
         </thead>
         <tbody>
           <tr>
 <td>960.css - <em>9989 bytes</em></td>
-<td><span class="badge bg-secondary">5772 bytes</span><br><span class="badge bg-secondary">19.48 ms</span></td>
-<td><span class="badge bg-secondary">5772 bytes</span><br><span class="badge bg-secondary">22.19 ms</span></td>
-<td><span class="badge bg-secondary">5772 bytes</span><br><span class="badge bg-danger">453.86 ms</span></td>
-<td><span class="badge bg-secondary">5772 bytes</span><br><span class="badge bg-secondary">133.09 ms</span></td>
-<td><span class="badge bg-success">5768 bytes</span><br><span class="badge bg-secondary">25.8 ms</span></td>
-<td><span class="badge bg-secondary">5772 bytes</span><br><span class="badge bg-secondary">5.2 ms</span></td>
-<td><span class="badge bg-danger">5773 bytes</span><br><span class="badge bg-secondary">71.47 ms</span></td>
-<td><span class="badge bg-secondary">5772 bytes</span><br><span class="badge bg-success">1.49 ms</span></td>
+<td><span class="badge bg-secondary">5772 bytes</span><br><span class="badge bg-secondary">8.29 ms</span></td>
+<td><span class="badge bg-secondary">5772 bytes</span><br><span class="badge bg-secondary">7.13 ms</span></td>
+<td><span class="badge bg-secondary">5772 bytes</span><br><span class="badge bg-danger">163.89 ms</span></td>
+<td><span class="badge bg-secondary">5772 bytes</span><br><span class="badge bg-secondary">59.05 ms</span></td>
+<td><span class="badge bg-success">5768 bytes</span><br><span class="badge bg-secondary">15.55 ms</span></td>
+<td><span class="badge bg-secondary">5772 bytes</span><br><span class="badge bg-secondary">1.91 ms</span></td>
+<td><span class="badge bg-secondary">5773 bytes</span><br><span class="badge bg-secondary">30.64 ms</span></td>
+<td><span class="badge bg-secondary">5772 bytes</span><br><span class="badge bg-success">0.41 ms</span></td>
+<td><span class="badge bg-danger">5939 bytes</span><br><span class="badge bg-secondary">4.05 ms</span></td>
 </tr>
 <tr>
 <td>animate.css - <em>95374 bytes</em></td>
-<td><span class="badge bg-danger">75274 bytes</span><br><span class="badge bg-secondary">80.83 ms</span></td>
-<td><span class="badge bg-secondary">74510 bytes</span><br><span class="badge bg-secondary">96.91 ms</span></td>
-<td><span class="badge bg-secondary">71723 bytes</span><br><span class="badge bg-danger">163.69 ms</span></td>
-<td><span class="badge bg-success">45487 bytes</span><br><span class="badge bg-secondary">159.71 ms</span></td>
-<td><span class="badge bg-secondary">73220 bytes</span><br><span class="badge bg-secondary">116.63 ms</span></td>
-<td><span class="badge bg-secondary">74520 bytes</span><br><span class="badge bg-secondary">64.28 ms</span></td>
-<td><span class="badge bg-secondary">71865 bytes</span><br><span class="badge bg-secondary">11.6 ms</span></td>
-<td><span class="badge bg-secondary">67675 bytes</span><br><span class="badge bg-success">3.36 ms</span></td>
+<td><span class="badge bg-secondary">75274 bytes</span><br><span class="badge bg-secondary">36.17 ms</span></td>
+<td><span class="badge bg-secondary">74510 bytes</span><br><span class="badge bg-secondary">44.7 ms</span></td>
+<td><span class="badge bg-secondary">71723 bytes</span><br><span class="badge bg-secondary">76.46 ms</span></td>
+<td><span class="badge bg-success">45487 bytes</span><br><span class="badge bg-danger">78.92 ms</span></td>
+<td><span class="badge bg-secondary">73220 bytes</span><br><span class="badge bg-secondary">39.08 ms</span></td>
+<td><span class="badge bg-secondary">74520 bytes</span><br><span class="badge bg-secondary">17.65 ms</span></td>
+<td><span class="badge bg-secondary">71865 bytes</span><br><span class="badge bg-secondary">6.23 ms</span></td>
+<td><span class="badge bg-secondary">67675 bytes</span><br><span class="badge bg-success">2.33 ms</span></td>
+<td><span class="badge bg-danger">78245 bytes</span><br><span class="badge bg-secondary">9.85 ms</span></td>
 </tr>
 <tr>
 <td>blueprint.css - <em>17422 bytes</em></td>
-<td><span class="badge bg-danger">10796 bytes</span><br><span class="badge bg-secondary">17.3 ms</span></td>
-<td><span class="badge bg-success">10646 bytes</span><br><span class="badge bg-secondary">46.81 ms</span></td>
-<td><span class="badge bg-secondary">10696 bytes</span><br><span class="badge bg-danger">80.71 ms</span></td>
-<td><span class="badge bg-secondary">10696 bytes</span><br><span class="badge bg-secondary">71.78 ms</span></td>
-<td><span class="badge bg-secondary">10677 bytes</span><br><span class="badge bg-secondary">28.62 ms</span></td>
-<td><span class="badge bg-secondary">10760 bytes</span><br><span class="badge bg-secondary">8.32 ms</span></td>
-<td><span class="badge bg-secondary">10778 bytes</span><br><span class="badge bg-secondary">1.88 ms</span></td>
-<td><span class="badge bg-secondary">10760 bytes</span><br><span class="badge bg-success">1.04 ms</span></td>
+<td><span class="badge bg-secondary">10796 bytes</span><br><span class="badge bg-secondary">8.78 ms</span></td>
+<td><span class="badge bg-success">10646 bytes</span><br><span class="badge bg-secondary">16 ms</span></td>
+<td><span class="badge bg-secondary">10696 bytes</span><br><span class="badge bg-danger">33.52 ms</span></td>
+<td><span class="badge bg-secondary">10696 bytes</span><br><span class="badge bg-secondary">24.23 ms</span></td>
+<td><span class="badge bg-secondary">10677 bytes</span><br><span class="badge bg-secondary">17.35 ms</span></td>
+<td><span class="badge bg-secondary">10760 bytes</span><br><span class="badge bg-secondary">3.08 ms</span></td>
+<td><span class="badge bg-secondary">10778 bytes</span><br><span class="badge bg-secondary">11.03 ms</span></td>
+<td><span class="badge bg-secondary">10760 bytes</span><br><span class="badge bg-success">1.27 ms</span></td>
+<td><span class="badge bg-danger">11074 bytes</span><br><span class="badge bg-secondary">2.32 ms</span></td>
 </tr>
 <tr>
 <td>bootstrap-4.css - <em>200078 bytes</em></td>
-<td><span class="badge bg-danger">161971 bytes</span><br><span class="badge bg-secondary">111.84 ms</span></td>
-<td><span class="badge bg-secondary">159896 bytes</span><br><span class="badge bg-secondary">228.21 ms</span></td>
-<td><span class="badge bg-secondary">160380 bytes</span><br><span class="badge bg-danger">503.11 ms</span></td>
-<td><span class="badge bg-success">147131 bytes</span><br><span class="badge bg-secondary">385.31 ms</span></td>
-<td><span class="badge bg-secondary">160157 bytes</span><br><span class="badge bg-secondary">167.38 ms</span></td>
-<td><span class="badge bg-secondary">161962 bytes</span><br><span class="badge bg-secondary">62.29 ms</span></td>
-<td><span class="badge bg-secondary">160913 bytes</span><br><span class="badge bg-secondary">17.49 ms</span></td>
-<td><span class="badge bg-secondary">154436 bytes</span><br><span class="badge bg-success">8.78 ms</span></td>
+<td><span class="badge bg-secondary">161971 bytes</span><br><span class="badge bg-secondary">65.9 ms</span></td>
+<td><span class="badge bg-secondary">159896 bytes</span><br><span class="badge bg-secondary">99.73 ms</span></td>
+<td><span class="badge bg-secondary">160380 bytes</span><br><span class="badge bg-danger">205.5 ms</span></td>
+<td><span class="badge bg-success">147131 bytes</span><br><span class="badge bg-secondary">161.39 ms</span></td>
+<td><span class="badge bg-secondary">160157 bytes</span><br><span class="badge bg-secondary">71.91 ms</span></td>
+<td><span class="badge bg-secondary">161962 bytes</span><br><span class="badge bg-secondary">25.43 ms</span></td>
+<td><span class="badge bg-secondary">160913 bytes</span><br><span class="badge bg-secondary">10.34 ms</span></td>
+<td><span class="badge bg-secondary">154436 bytes</span><br><span class="badge bg-success">4.5 ms</span></td>
+<td><span class="badge bg-danger">165538 bytes</span><br><span class="badge bg-secondary">29.14 ms</span></td>
 </tr>
 <tr>
 <td>bootstrap-5.css - <em>205481 bytes</em></td>
-<td><span class="badge bg-secondary">163824 bytes</span><br><span class="badge bg-secondary">122.55 ms</span></td>
-<td><span class="badge bg-secondary">161691 bytes</span><br><span class="badge bg-secondary">166.77 ms</span></td>
-<td><span class="badge bg-secondary">162285 bytes</span><br><span class="badge bg-danger">341.85 ms</span></td>
-<td><span class="badge bg-secondary">161473 bytes</span><br><span class="badge bg-secondary">339.7 ms</span></td>
-<td><span class="badge bg-secondary">161483 bytes</span><br><span class="badge bg-secondary">108.37 ms</span></td>
-<td><span class="badge bg-danger">163830 bytes</span><br><span class="badge bg-secondary">38.65 ms</span></td>
-<td><span class="badge bg-secondary">163143 bytes</span><br><span class="badge bg-secondary">22.02 ms</span></td>
-<td><span class="badge bg-success">160889 bytes</span><br><span class="badge bg-success">8.01 ms</span></td>
+<td><span class="badge bg-secondary">163824 bytes</span><br><span class="badge bg-secondary">62.63 ms</span></td>
+<td><span class="badge bg-secondary">161691 bytes</span><br><span class="badge bg-secondary">66.63 ms</span></td>
+<td><span class="badge bg-secondary">162285 bytes</span><br><span class="badge bg-danger">175.12 ms</span></td>
+<td><span class="badge bg-secondary">161473 bytes</span><br><span class="badge bg-secondary">173.64 ms</span></td>
+<td><span class="badge bg-secondary">161483 bytes</span><br><span class="badge bg-secondary">49.25 ms</span></td>
+<td><span class="badge bg-secondary">163830 bytes</span><br><span class="badge bg-secondary">17.96 ms</span></td>
+<td><span class="badge bg-secondary">163143 bytes</span><br><span class="badge bg-secondary">10.47 ms</span></td>
+<td><span class="badge bg-success">160889 bytes</span><br><span class="badge bg-success">5.06 ms</span></td>
+<td><span class="badge bg-danger">166940 bytes</span><br><span class="badge bg-secondary">22.02 ms</span></td>
 </tr>
 <tr>
 <td>font-awesome-all.css - <em>73117 bytes</em></td>
-<td><span class="badge bg-secondary">58568 bytes</span><br><span class="badge bg-secondary">18.69 ms</span></td>
-<td><span class="badge bg-secondary">58568 bytes</span><br><span class="badge bg-secondary">31.29 ms</span></td>
-<td><span class="badge bg-secondary">58929 bytes</span><br><span class="badge bg-secondary">123.73 ms</span></td>
-<td><span class="badge bg-secondary">58563 bytes</span><br><span class="badge bg-danger">127.14 ms</span></td>
-<td><span class="badge bg-success">53128 bytes</span><br><span class="badge bg-secondary">38.86 ms</span></td>
-<td><span class="badge bg-secondary">53184 bytes</span><br><span class="badge bg-secondary">17.79 ms</span></td>
-<td><span class="badge bg-danger">58980 bytes</span><br><span class="badge bg-secondary">5.56 ms</span></td>
-<td><span class="badge bg-secondary">58791 bytes</span><br><span class="badge bg-success">2.66 ms</span></td>
+<td><span class="badge bg-secondary">58568 bytes</span><br><span class="badge bg-secondary">11.06 ms</span></td>
+<td><span class="badge bg-secondary">58568 bytes</span><br><span class="badge bg-secondary">14.79 ms</span></td>
+<td><span class="badge bg-secondary">58929 bytes</span><br><span class="badge bg-secondary">60.51 ms</span></td>
+<td><span class="badge bg-secondary">58563 bytes</span><br><span class="badge bg-danger">70.14 ms</span></td>
+<td><span class="badge bg-success">53128 bytes</span><br><span class="badge bg-secondary">19.25 ms</span></td>
+<td><span class="badge bg-secondary">53184 bytes</span><br><span class="badge bg-secondary">8.61 ms</span></td>
+<td><span class="badge bg-secondary">58980 bytes</span><br><span class="badge bg-secondary">4.77 ms</span></td>
+<td><span class="badge bg-secondary">58791 bytes</span><br><span class="badge bg-success">2.11 ms</span></td>
+<td><span class="badge bg-danger">59081 bytes</span><br><span class="badge bg-secondary">5.46 ms</span></td>
 </tr>
 <tr>
 <td>foundation.css - <em>168014 bytes</em></td>
-<td><span class="badge bg-danger">132603 bytes</span><br><span class="badge bg-secondary">96.71 ms</span></td>
-<td><span class="badge bg-secondary">125186 bytes</span><br><span class="badge bg-secondary">93.19 ms</span></td>
-<td><span class="badge bg-secondary">126470 bytes</span><br><span class="badge bg-danger">277.04 ms</span></td>
-<td><span class="badge bg-success">107261 bytes</span><br><span class="badge bg-secondary">259.38 ms</span></td>
-<td><span class="badge bg-secondary">124232 bytes</span><br><span class="badge bg-secondary">80.54 ms</span></td>
-<td><span class="badge bg-secondary">132554 bytes</span><br><span class="badge bg-secondary">28.87 ms</span></td>
-<td><span class="badge bg-secondary">131891 bytes</span><br><span class="badge bg-secondary">12.83 ms</span></td>
-<td><span class="badge bg-secondary">124579 bytes</span><br><span class="badge bg-success">5.23 ms</span></td>
+<td><span class="badge bg-secondary">132603 bytes</span><br><span class="badge bg-secondary">54.61 ms</span></td>
+<td><span class="badge bg-secondary">125186 bytes</span><br><span class="badge bg-secondary">49.82 ms</span></td>
+<td><span class="badge bg-secondary">126470 bytes</span><br><span class="badge bg-secondary">128.96 ms</span></td>
+<td><span class="badge bg-success">107261 bytes</span><br><span class="badge bg-danger">133.87 ms</span></td>
+<td><span class="badge bg-secondary">124232 bytes</span><br><span class="badge bg-secondary">43 ms</span></td>
+<td><span class="badge bg-secondary">132554 bytes</span><br><span class="badge bg-secondary">16.4 ms</span></td>
+<td><span class="badge bg-secondary">131891 bytes</span><br><span class="badge bg-secondary">9.16 ms</span></td>
+<td><span class="badge bg-secondary">124579 bytes</span><br><span class="badge bg-success">4.31 ms</span></td>
+<td><span class="badge bg-danger">136012 bytes</span><br><span class="badge bg-secondary">16.46 ms</span></td>
 </tr>
 <tr>
 <td>inuit.css - <em>53050 bytes</em></td>
-<td><span class="badge bg-secondary">18184 bytes</span><br><span class="badge bg-secondary">12.46 ms</span></td>
-<td><span class="badge bg-success">17635 bytes</span><br><span class="badge bg-secondary">19.58 ms</span></td>
-<td><span class="badge bg-secondary">18105 bytes</span><br><span class="badge bg-danger">87.4 ms</span></td>
-<td><span class="badge bg-secondary">17961 bytes</span><br><span class="badge bg-secondary">57.64 ms</span></td>
-<td><span class="badge bg-secondary">17878 bytes</span><br><span class="badge bg-secondary">23.9 ms</span></td>
-<td><span class="badge bg-secondary">18216 bytes</span><br><span class="badge bg-secondary">7.46 ms</span></td>
-<td><span class="badge bg-danger">18325 bytes</span><br><span class="badge bg-secondary">2.93 ms</span></td>
-<td><span class="badge bg-secondary">17948 bytes</span><br><span class="badge bg-success">1.15 ms</span></td>
+<td><span class="badge bg-secondary">18184 bytes</span><br><span class="badge bg-secondary">19.08 ms</span></td>
+<td><span class="badge bg-success">17635 bytes</span><br><span class="badge bg-secondary">23.32 ms</span></td>
+<td><span class="badge bg-secondary">18105 bytes</span><br><span class="badge bg-danger">24.01 ms</span></td>
+<td><span class="badge bg-secondary">17961 bytes</span><br><span class="badge bg-secondary">22.02 ms</span></td>
+<td><span class="badge bg-secondary">17878 bytes</span><br><span class="badge bg-secondary">11.46 ms</span></td>
+<td><span class="badge bg-secondary">18216 bytes</span><br><span class="badge bg-secondary">3.29 ms</span></td>
+<td><span class="badge bg-secondary">18325 bytes</span><br><span class="badge bg-secondary">2.46 ms</span></td>
+<td><span class="badge bg-secondary">17948 bytes</span><br><span class="badge bg-success">0.9 ms</span></td>
+<td><span class="badge bg-danger">20320 bytes</span><br><span class="badge bg-secondary">3.08 ms</span></td>
 </tr>
 <tr>
 <td>normalize.css - <em>6138 bytes</em></td>
-<td><span class="badge bg-secondary">1815 bytes</span><br><span class="badge bg-secondary">1.6 ms</span></td>
-<td><span class="badge bg-secondary">1742 bytes</span><br><span class="badge bg-secondary">2.4 ms</span></td>
-<td><span class="badge bg-secondary">1802 bytes</span><br><span class="badge bg-danger">10.51 ms</span></td>
-<td><span class="badge bg-secondary">1802 bytes</span><br><span class="badge bg-secondary">7.24 ms</span></td>
-<td><span class="badge bg-success">1692 bytes</span><br><span class="badge bg-secondary">1.79 ms</span></td>
-<td><span class="badge bg-danger">1816 bytes</span><br><span class="badge bg-secondary">0.98 ms</span></td>
-<td><span class="badge bg-danger">1816 bytes</span><br><span class="badge bg-secondary">0.97 ms</span></td>
-<td><span class="badge bg-secondary">1704 bytes</span><br><span class="badge bg-success">0.24 ms</span></td>
+<td><span class="badge bg-secondary">1815 bytes</span><br><span class="badge bg-secondary">0.69 ms</span></td>
+<td><span class="badge bg-secondary">1742 bytes</span><br><span class="badge bg-secondary">2 ms</span></td>
+<td><span class="badge bg-secondary">1802 bytes</span><br><span class="badge bg-secondary">3.04 ms</span></td>
+<td><span class="badge bg-secondary">1802 bytes</span><br><span class="badge bg-danger">3.33 ms</span></td>
+<td><span class="badge bg-success">1692 bytes</span><br><span class="badge bg-secondary">1.01 ms</span></td>
+<td><span class="badge bg-secondary">1816 bytes</span><br><span class="badge bg-secondary">0.36 ms</span></td>
+<td><span class="badge bg-secondary">1816 bytes</span><br><span class="badge bg-secondary">1.24 ms</span></td>
+<td><span class="badge bg-secondary">1704 bytes</span><br><span class="badge bg-success">0.21 ms</span></td>
+<td><span class="badge bg-danger">1875 bytes</span><br><span class="badge bg-secondary">0.43 ms</span></td>
 </tr>
 <tr>
 <td>pure.css - <em>28843 bytes</em></td>
-<td><span class="badge bg-danger">16797 bytes</span><br><span class="badge bg-secondary">8.24 ms</span></td>
-<td><span class="badge bg-secondary">16500 bytes</span><br><span class="badge bg-secondary">13.93 ms</span></td>
-<td><span class="badge bg-secondary">16660 bytes</span><br><span class="badge bg-danger">48.28 ms</span></td>
-<td><span class="badge bg-success">15986 bytes</span><br><span class="badge bg-secondary">48.22 ms</span></td>
-<td><span class="badge bg-secondary">16733 bytes</span><br><span class="badge bg-secondary">13.01 ms</span></td>
-<td><span class="badge bg-secondary">16780 bytes</span><br><span class="badge bg-secondary">5.4 ms</span></td>
-<td><span class="badge bg-secondary">16773 bytes</span><br><span class="badge bg-secondary">3.65 ms</span></td>
-<td><span class="badge bg-secondary">16267 bytes</span><br><span class="badge bg-success">0.9 ms</span></td>
+<td><span class="badge bg-secondary">16797 bytes</span><br><span class="badge bg-secondary">4.14 ms</span></td>
+<td><span class="badge bg-secondary">16500 bytes</span><br><span class="badge bg-secondary">7.97 ms</span></td>
+<td><span class="badge bg-secondary">16660 bytes</span><br><span class="badge bg-secondary">21.89 ms</span></td>
+<td><span class="badge bg-success">15986 bytes</span><br><span class="badge bg-danger">22 ms</span></td>
+<td><span class="badge bg-secondary">16733 bytes</span><br><span class="badge bg-secondary">5.74 ms</span></td>
+<td><span class="badge bg-secondary">16780 bytes</span><br><span class="badge bg-secondary">2.27 ms</span></td>
+<td><span class="badge bg-secondary">16773 bytes</span><br><span class="badge bg-secondary">1.61 ms</span></td>
+<td><span class="badge bg-secondary">16267 bytes</span><br><span class="badge bg-success">0.72 ms</span></td>
+<td><span class="badge bg-danger">17380 bytes</span><br><span class="badge bg-secondary">3.58 ms</span></td>
 </tr>
 <tr>
 <td>reset.css - <em>1092 bytes</em></td>
-<td><span class="badge bg-secondary">773 bytes</span><br><span class="badge bg-secondary">0.53 ms</span></td>
-<td><span class="badge bg-secondary">773 bytes</span><br><span class="badge bg-secondary">0.96 ms</span></td>
-<td><span class="badge bg-secondary">773 bytes</span><br><span class="badge bg-secondary">2.85 ms</span></td>
-<td><span class="badge bg-secondary">773 bytes</span><br><span class="badge bg-danger">3 ms</span></td>
-<td><span class="badge bg-success">747 bytes</span><br><span class="badge bg-secondary">1.59 ms</span></td>
-<td><span class="badge bg-secondary">773 bytes</span><br><span class="badge bg-secondary">0.3 ms</span></td>
-<td><span class="badge bg-danger">774 bytes</span><br><span class="badge bg-secondary">0.7 ms</span></td>
-<td><span class="badge bg-secondary">773 bytes</span><br><span class="badge bg-success">0.16 ms</span></td>
+<td><span class="badge bg-secondary">773 bytes</span><br><span class="badge bg-secondary">0.28 ms</span></td>
+<td><span class="badge bg-secondary">773 bytes</span><br><span class="badge bg-secondary">0.49 ms</span></td>
+<td><span class="badge bg-secondary">773 bytes</span><br><span class="badge bg-secondary">1.47 ms</span></td>
+<td><span class="badge bg-secondary">773 bytes</span><br><span class="badge bg-danger">1.51 ms</span></td>
+<td><span class="badge bg-success">747 bytes</span><br><span class="badge bg-secondary">0.92 ms</span></td>
+<td><span class="badge bg-secondary">773 bytes</span><br><span class="badge bg-secondary">0.16 ms</span></td>
+<td><span class="badge bg-secondary">774 bytes</span><br><span class="badge bg-secondary">0.56 ms</span></td>
+<td><span class="badge bg-secondary">773 bytes</span><br><span class="badge bg-success">0.12 ms</span></td>
+<td><span class="badge bg-danger">969 bytes</span><br><span class="badge bg-secondary">0.19 ms</span></td>
 </tr>
 <tr>
 <td>tailwind.css - <em>2380419 bytes</em></td>
-<td><span class="badge bg-secondary">1941795 bytes</span><br><span class="badge bg-secondary">974.56 ms</span></td>
-<td><span class="badge bg-secondary">1941490 bytes</span><br><span class="badge bg-secondary">931.06 ms</span></td>
-<td><span class="badge bg-secondary">1925626 bytes</span><br><span class="badge bg-secondary">3136.25 ms</span></td>
-<td><span class="badge bg-secondary">1787893 bytes</span><br><span class="badge bg-danger">3146.95 ms</span></td>
-<td><span class="badge bg-success">1652840 bytes</span><br><span class="badge bg-secondary">719.28 ms</span></td>
-<td><span class="badge bg-secondary">1944385 bytes</span><br><span class="badge bg-secondary">346.11 ms</span></td>
-<td><span class="badge bg-danger">1961295 bytes</span><br><span class="badge bg-secondary">371.86 ms</span></td>
-<td><span class="badge bg-secondary">1960722 bytes</span><br><span class="badge bg-success">86.56 ms</span></td>
+<td><span class="badge bg-secondary">1941795 bytes</span><br><span class="badge bg-secondary">430.19 ms</span></td>
+<td><span class="badge bg-secondary">1941490 bytes</span><br><span class="badge bg-secondary">500.54 ms</span></td>
+<td><span class="badge bg-secondary">1925626 bytes</span><br><span class="badge bg-secondary">1551.81 ms</span></td>
+<td><span class="badge bg-secondary">1787893 bytes</span><br><span class="badge bg-danger">1711.37 ms</span></td>
+<td><span class="badge bg-success">1652840 bytes</span><br><span class="badge bg-secondary">416.36 ms</span></td>
+<td><span class="badge bg-secondary">1944385 bytes</span><br><span class="badge bg-secondary">184.91 ms</span></td>
+<td><span class="badge bg-secondary">1961295 bytes</span><br><span class="badge bg-secondary">98.58 ms</span></td>
+<td><span class="badge bg-secondary">1960722 bytes</span><br><span class="badge bg-success">37.86 ms</span></td>
+<td><span class="badge bg-danger">1999094 bytes</span><br><span class="badge bg-secondary">153.1 ms</span></td>
 </tr>
 <tr>
 <td><span class="text-uppercase fw-bold">Total</span> - <em>3239017 bytes</em></td>
-<td><span class="badge bg-secondary">2588172 bytes</span><br><span class="badge bg-secondary">1464.79 ms</span></td>
-<td><span class="badge bg-secondary">2574409 bytes</span><br><span class="badge bg-secondary">1653.3 ms</span></td>
-<td><span class="badge bg-secondary">2559221 bytes</span><br><span class="badge bg-danger">5229.28 ms</span></td>
-<td><span class="badge bg-secondary">2360798 bytes</span><br><span class="badge bg-secondary">4739.16 ms</span></td>
-<td><span class="badge bg-success">2278555 bytes</span><br><span class="badge bg-secondary">1325.77 ms</span></td>
-<td><span class="badge bg-secondary">2584552 bytes</span><br><span class="badge bg-secondary">585.65 ms</span></td>
-<td><span class="badge bg-danger">2602326 bytes</span><br><span class="badge bg-secondary">522.96 ms</span></td>
-<td><span class="badge bg-secondary">2580316 bytes</span><br><span class="badge bg-success">119.58 ms</span></td>
+<td><span class="badge bg-secondary">2588172 bytes</span><br><span class="badge bg-secondary">701.82 ms</span></td>
+<td><span class="badge bg-secondary">2574409 bytes</span><br><span class="badge bg-secondary">833.12 ms</span></td>
+<td><span class="badge bg-secondary">2559221 bytes</span><br><span class="badge bg-secondary">2446.18 ms</span></td>
+<td><span class="badge bg-secondary">2360798 bytes</span><br><span class="badge bg-danger">2461.47 ms</span></td>
+<td><span class="badge bg-success">2278555 bytes</span><br><span class="badge bg-secondary">690.88 ms</span></td>
+<td><span class="badge bg-secondary">2584552 bytes</span><br><span class="badge bg-secondary">282.03 ms</span></td>
+<td><span class="badge bg-secondary">2602326 bytes</span><br><span class="badge bg-secondary">187.09 ms</span></td>
+<td><span class="badge bg-secondary">2580316 bytes</span><br><span class="badge bg-success">59.8 ms</span></td>
+<td><span class="badge bg-danger">2662467 bytes</span><br><span class="badge bg-secondary">249.68 ms</span></td>
 </tr>
         </tbody>
       </table>
     </div>
     <div class="machine-info my-2">
       <h2 class="h4">Benchmark info:</h2>
-      <pre class="bg-light border text-dark p-3">Date: Thu, 13 Jan 2022 19:46:58 GMT
-CPU: Intel(R) Core(TM) i7-7700K CPU @ 4.20GHz
-OS: Linux x64 4.4.0-19041-Microsoft
-Node.js: v16.13.2</pre>
+      <pre class="bg-light border text-dark p-3">Date: Fri, 08 Sep 2023 20:55:09 GMT
+CPU: Apple M2
+OS: Darwin arm64 22.6.0
+Node.js: v20.4.0</pre>
     </div>
   </div>
 </body>

--- a/lib/minify.js
+++ b/lib/minify.js
@@ -5,6 +5,7 @@ const path = require('path');
 const process = require('process');
 const { Buffer } = require('buffer');
 const Q = require('q');
+const postcss = require('postcss');
 
 const CleanCSS = require('clean-css');
 const cssnano = require('cssnano');
@@ -12,6 +13,7 @@ const csso = require('csso');
 const gzipSize = require('gzip-size');
 const esbuild = require('esbuild');
 const parcelCss = require('@parcel/css');
+const postcssMinify = require('@csstools/postcss-minify');
 
 // MINIFIERS
 const minifiers = {
@@ -42,7 +44,12 @@ const minifiers = {
   },
   '@parcel/css': source => {
     return parcelCss.transform({ filename: '', code: Buffer.from(source), minify: true }).code;
-  }
+  },
+  '@csstools/postcss-minify': source => {
+    return postcss([postcssMinify()]).process(source, { from: undefined }).then(result => {
+      return result.css;
+    });
+  },
 };
 
 const gzippedSize = {};

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,7 @@
         "css-minification-benchmark": "bin/bench.js"
       },
       "devDependencies": {
+        "@csstools/postcss-minify": "^1.0.0",
         "@parcel/css": "^1.0.1",
         "clean-css": "^5.2.2",
         "cssnano": "^5.0.15",
@@ -495,6 +496,50 @@
       },
       "engines": {
         "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@csstools/css-tokenizer": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@csstools/css-tokenizer/-/css-tokenizer-2.2.0.tgz",
+      "integrity": "sha512-wErmsWCbsmig8sQKkM6pFhr/oPha1bHfvxsUY5CYSQxwyhA9Ulrs8EqCgClhg4Tgg2XapVstGqSVcz0xOYizZA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "engines": {
+        "node": "^14 || ^16 || >=18"
+      }
+    },
+    "node_modules/@csstools/postcss-minify": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@csstools/postcss-minify/-/postcss-minify-1.0.0.tgz",
+      "integrity": "sha512-gM0ES6+YsXqiqnute1yxrSnp8veYVGOHq1jeedgMdTZOvCX8ueUU/ytdXsopZuKO/jvHP/LlUIfYOj569nJnyg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "dependencies": {
+        "@csstools/css-tokenizer": "^2.1.1"
+      },
+      "engines": {
+        "node": "^14 || ^16 || >=18"
+      },
+      "peerDependencies": {
+        "postcss": "^8.4"
       }
     },
     "node_modules/@eslint/eslintrc": {
@@ -8081,6 +8126,21 @@
       "requires": {
         "@babel/helper-validator-identifier": "^7.16.7",
         "to-fast-properties": "^2.0.0"
+      }
+    },
+    "@csstools/css-tokenizer": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@csstools/css-tokenizer/-/css-tokenizer-2.2.0.tgz",
+      "integrity": "sha512-wErmsWCbsmig8sQKkM6pFhr/oPha1bHfvxsUY5CYSQxwyhA9Ulrs8EqCgClhg4Tgg2XapVstGqSVcz0xOYizZA==",
+      "dev": true
+    },
+    "@csstools/postcss-minify": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@csstools/postcss-minify/-/postcss-minify-1.0.0.tgz",
+      "integrity": "sha512-gM0ES6+YsXqiqnute1yxrSnp8veYVGOHq1jeedgMdTZOvCX8ueUU/ytdXsopZuKO/jvHP/LlUIfYOj569nJnyg==",
+      "dev": true,
+      "requires": {
+        "@csstools/css-tokenizer": "^2.1.1"
       }
     },
     "@eslint/eslintrc": {

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
   "main": "lib/index.js",
   "dependencies": {},
   "devDependencies": {
+    "@csstools/postcss-minify": "^1.0.0",
     "@parcel/css": "^1.0.1",
     "clean-css": "^5.2.2",
     "cssnano": "^5.0.15",


### PR DESCRIPTION
[`@csstools/postcss-minify`](https://github.com/csstools/postcss-plugins/tree/main/plugins/postcss-minify#readme) is a fast minifier for PostCSS that focusses on correctness and compliance. It doesn't produce as outputs that are as small as tools like cssnano, but it's more correct and much faster.